### PR TITLE
Fix species typo in lumped species list for Iy

### DIFF
--- a/gcpy/benchmark_categories.yml
+++ b/gcpy/benchmark_categories.yml
@@ -73,7 +73,7 @@ FullChemBenchmark:
       - IBr
       - ICl
       - IO
-      - INO2
+      - IONO
       - IONO2
       - CH3I
       - CH2I2


### PR DESCRIPTION
INO2 included in iodine list, but this RO2 from ISOP+NO3. For iodine, INO, IONO, and IONO2 should be the species included. INO2 has therefore been replaced with IONO.