### PR TITLE
Simple CS->CS regridder

### DIFF
--- a/gcpy/cs_regrid.py
+++ b/gcpy/cs_regrid.py
@@ -61,8 +61,7 @@ def reformat_dims(ds, format, towards_common):
         return ds_in
 
     def ravel_checkpoint_lat(ds_out):
-        assert ds_in.dims['X'] == ds_in.dims['Y']
-        cs_res = ds_in.dims['X']
+        cs_res = ds_out.dims['lon']
         ds_out = ds_out.stack(lat=['lat_level_0', 'lat_level_1'])
         ds_out = ds_out.assign_coords({
             'lat': np.linspace(1, 6*cs_res, 6*cs_res)

--- a/gcpy/cs_regrid.py
+++ b/gcpy/cs_regrid.py
@@ -188,7 +188,12 @@ if __name__ == '__main__':
         # For each output face, sum regridded input faces
         oface_datasets = []
         for oface in range(6):
-            oface_regridded = [regridder(ds_in.isel(F=iface).drop('F'), keep_attrs=True) for iface, regridder in regridders[oface].items()]
+            oface_regridded = []
+            for iface, regridder in regridders[oface].items():
+                ds_iface = ds_in.isel(F=iface)
+                if 'F' in ds_iface.dims:
+                    ds_iface = ds_iface.drop('F')
+                oface_regridded.append(regridder(ds_iface, keep_attrs=True))
             oface_regridded = xr.concat(oface_regridded, dim='intersecting_ifaces').sum('intersecting_ifaces')
             oface_datasets.append(oface_regridded)
         ds_out = xr.concat(oface_datasets, dim='F')

--- a/gcpy/cs_regrid.py
+++ b/gcpy/cs_regrid.py
@@ -1,0 +1,167 @@
+import argparse
+import hashlib
+import os.path
+
+import numpy as np
+import xarray as xr
+try:
+    import xesmf as xe
+    from distutils.version import LooseVersion
+    if LooseVersion(xesmf.__version__) < LooseVersion("0.2.1"):
+        raise ImportError("cs_regrid.py requires xESMF version 0.2.1 or higher.")
+except ImportError as e:
+    print('cs_regrid.py requires xESMF version 0.2.1 or higher!\n\nSee the installation instructions here: https://xesmf.readthedocs.io/en/latest/installation.html\n')
+import pandas as pd
+
+from gcpy.grid.horiz import make_grid_SG
+
+
+def sg_hash(cs_res, stretch_factor: float, target_lat: float, target_lon: float):
+    return hashlib.sha1('cs={cs_res},sf={stretch_factor:.5f},tx={target_lon:.5f},ty={target_lat:.5f}'.format(
+        stretch_factor=stretch_factor,
+        target_lat=target_lat,
+        target_lon=target_lon,
+        cs_res=cs_res
+    ).encode()).hexdigest()[:7]
+
+
+def make_regridder_S2S(csres_in, csres_out, sf_in=1, tlat_in=-90, tlon_in=170, sf_out=1, tlat_out=-90, tlon_out=170, weightsdir='.'):
+    igrid, igrid_list = make_grid_SG(csres_in, stretch_factor=sf_in, target_lat=tlat_in, target_lon=tlon_in)
+    ogrid, ogrid_list = make_grid_SG(csres_out, stretch_factor=sf_out, target_lat=tlat_out, target_lon=tlon_out)
+    regridder_list = []
+    for o_face in range(6):
+        regridder_list.append({})
+        for i_face in range(6):
+            weights_fname = f'conservative_sg{sg_hash(csres_in, sf_in, tlat_in, tlon_in)}_F{i_face}_sg{sg_hash(csres_out, sf_out, tlat_out, tlon_out)}_F{o_face}.nc'
+            weights_file = os.path.join(weightsdir, weights_fname)
+            reuse_weights = os.path.exists(weights_file)
+            try:
+                regridder = xe.Regridder(igrid_list[i_face],
+                                         ogrid_list[o_face],
+                                         method='conservative',
+                                         filename=weights_file,
+                                         reuse_weights=reuse_weights)
+                regridder_list[-1][i_face] = regridder
+            except ValueError:
+                print(f"iface {i_face} doesn't intersect oface {o_face}")
+    return regridder_list
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create a restart file for GCHP')
+    parser.add_argument('-i', '--filein',
+                        metavar='FILEIN',
+                        type=str,
+                        required=True,
+                        help='input file')
+    parser.add_argument('-o', '--fileout',
+                        metavar='RES',
+                        type=str,
+                        required=True,
+                        help='output file name')
+    parser.add_argument('--sg_params_in',
+                        metavar='SF X Y',
+                        type=float,
+                        nargs=3,
+                        default=[1.0, 170.0, -90.0],
+                        help='input grid stretched-grid definition')
+    parser.add_argument('--sg_params_out',
+                        metavar='SF X Y',
+                        type=float,
+                        nargs=3,
+                        default=[1.0, 170.0, -90.0],
+                        help='output grid stretched-grid definition')
+    parser.add_argument('--cs_res_out',
+                        metavar='RES',
+                        type=int,
+                        required=True,
+                        help='output grid cubed-sphere resolution')
+    parser.add_argument('--stacked_in',
+                        action='store_true',
+                        help='output file in stacked format')
+    parser.add_argument('--stacked_out',
+                        action='store_true',
+                        help='output file in stacked format')
+    args = parser.parse_args()
+
+    ds_in = xr.open_dataset(args.filein, decode_cf=False)
+
+    if args.stacked_in:
+        cs_res_in = ds_in.dims['lat'] // 6
+        y = np.linspace(1, cs_res_in, cs_res_in)
+        nf = np.linspace(1, 6, 6)
+        mi = pd.MultiIndex.from_product([nf, y])
+        ds_in = ds_in.assign_coords({'lat': mi})
+        ds_in = ds_in.unstack('lat').rename({
+            'lat_level_0': 'face',
+            'lat_level_1': 'Y',
+            'lon': 'X',
+        })
+        ds_in = ds_in.transpose('time', 'lev', 'face', 'Y', 'X')
+    else:
+        cs_res_in = ds_in.dims['Ydim']
+        ds_in = ds_in.unstack('lat').rename({
+            'nf': 'face',
+            'Ydim': 'Y',
+            'Xdim': 'X',
+        })
+        ds_in = ds_in.transpose('time', 'lev', 'face', 'Y', 'X')
+
+    ds_in['conservative_check'] = xr.DataArray(
+        np.ones((ds_in.dims['time'], ds_in.dims['lev'], ds_in.dims['face'], ds_in.dims['Y'], ds_in.dims['X'])),
+        dims=['time', 'lev', 'face', 'Y', 'X']
+    )
+
+    regridders = make_regridder_S2S(
+        cs_res_in, args.cs_res_out,
+        sf_in=args.sg_params_in[0], tlon_in=args.sg_params_in[1], tlat_in=args.sg_params_in[2],
+        sf_out=args.sg_params_out[0], tlon_out=args.sg_params_out[1], tlat_out=args.sg_params_out[2]
+    )
+
+    oface_datasets = []
+    for oface in range(6):
+        oface_regridded = [regridder(ds_in.isel(face=iface).drop('face'), keep_attrs=True) for iface, regridder in regridders[oface].items()]
+        oface_regridded = xr.concat(oface_regridded, dim='intersecting_ifaces').sum('intersecting_ifaces')
+        oface_datasets.append(oface_regridded)
+
+    ds_out = xr.concat(oface_datasets, dim='face')
+
+    ds_out = ds_out.rename({
+        'face': 'nf',
+        'y': 'Ydim',
+        'x': 'Xdim',
+    })
+    ds_out = ds_out.transpose('time', 'lev', 'nf', 'Ydim', 'Xdim')
+    ds_out = ds_out.drop(['lat', 'lon'])
+
+    if args.stacked_out:
+        cs_res_out = ds_out.dims['Xdim']
+        ds_out = ds_out.stack(lat=['nf', 'Ydim'])
+        ds_out = ds_out.rename({'Xdim': 'lon'})
+        ds_out = ds_out.assign_coords({
+            'lat': np.linspace(1, 6*cs_res_out, 6*cs_res_out), 'lon': np.linspace(1, cs_res_out, cs_res_out)
+        })
+        ds_out = ds_out.transpose('time', 'lev', 'lat', 'lon')
+    else:
+        cs_res_out = ds_out.dims['Xdim']
+        ds_out = ds_out.assign_coords({
+            'nf': np.linspace(1, 6, 6),
+            'Ydim': np.linspace(1, cs_res_out, cs_res_out),
+            'Xdim': np.linspace(1, cs_res_out, cs_res_out),
+        })
+        ds_out = ds_out.transpose('time', 'lev', 'nf', 'Ydim', 'Xdim')
+
+    # Review conservative check
+    score = 1 + (1 - abs(ds_out['conservative_check']))
+    print('Conservative check:')
+    print(f'    - P95 score: {score.quantile(0.95).item()}')
+    print(f'    - P99 score: {score.quantile(0.99).item()}')
+    ds_out = ds_out.drop(['conservative_check'])
+
+    # Write dataset
+    ds_out.to_netcdf(
+        args.fileout,
+        format='NETCDF4_CLASSIC'
+    )
+
+    print(ds_out)

--- a/gcpy/cs_regrid.py
+++ b/gcpy/cs_regrid.py
@@ -7,13 +7,13 @@ import xarray as xr
 try:
     import xesmf as xe
     from distutils.version import LooseVersion
-    if LooseVersion(xesmf.__version__) < LooseVersion("0.2.1"):
+    if LooseVersion(xe.__version__) < LooseVersion("0.2.1"):
         raise ImportError("cs_regrid.py requires xESMF version 0.2.1 or higher.")
 except ImportError as e:
     print('cs_regrid.py requires xESMF version 0.2.1 or higher!\n\nSee the installation instructions here: https://xesmf.readthedocs.io/en/latest/installation.html\n')
 import pandas as pd
 
-from gcpy.grid.horiz import make_grid_SG
+from .grid import make_grid_SG
 
 
 def sg_hash(cs_res, stretch_factor: float, target_lat: float, target_lon: float):

--- a/gcpy/grid.py
+++ b/gcpy/grid.py
@@ -4,6 +4,7 @@ from numpy import asarray
 import scipy.sparse
 from itertools import product
 from .util import get_shape_of_data
+from .grid_stretching_transforms import scs_transform
 
 
 def get_troposphere_mask(ds):
@@ -549,6 +550,31 @@ def make_grid_CS(csres,out_extent=[0,360,-90,90]):
                           'lat_b': csgrid['lat_b'][i], 
                           'lon_b': csgrid['lon_b'][i]}
 
+    return [csgrid, csgrid_list]
+
+def make_grid_SG(csres, stretch_factor, target_lon, target_lat):
+    csgrid = csgrid_GMAO(csres, offset=0)
+    csgrid_list = [None] * 6
+    for i in range(6):
+        lat = csgrid['lat'][i].flatten()
+        lon = csgrid['lon'][i].flatten()
+        lon, lat = scs_transform(lon, lat, stretch_factor, target_lon, target_lat)
+        lat = lat.reshape((csres, csres))
+        lon = lon.reshape((csres, csres))
+        lat_b = csgrid['lat_b'][i].flatten()
+        lon_b = csgrid['lon_b'][i].flatten()
+        lon_b, lat_b = scs_transform(lon_b, lat_b, stretch_factor, target_lon, target_lat)
+        lat_b = lat_b.reshape((csres + 1, csres + 1))
+        lon_b = lon_b.reshape((csres + 1, csres + 1))
+        csgrid_list[i] = {'lat': lat,
+                          'lon': lon,
+                          'lat_b': lat_b,
+                          'lon_b': lon_b}
+    for i in range(6):
+        csgrid['lat'][i] = csgrid_list[i]['lat']
+        csgrid['lon'][i] = csgrid_list[i]['lon']
+        csgrid['lat_b'][i] = csgrid_list[i]['lat_b']
+        csgrid['lon_b'][i] = csgrid_list[i]['lon_b']
     return [csgrid, csgrid_list]
 
 

--- a/gcpy/grid_stretching_transforms.py
+++ b/gcpy/grid_stretching_transforms.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+
+def rotate_vectors(x, y, z, k, theta):
+    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
+    z = np.atleast_1d(z)
+    v = np.moveaxis(np.array([x, y, z]), 0, -1)  # shape: (..., 3)
+    v = v*np.cos(theta) + np.cross(k, v) * np.sin(theta) + k[np.newaxis, :] * np.dot(v, k)[:, np.newaxis] * (1-np.cos(theta))
+    return v[..., 0], v[..., 1], v[..., 2]
+
+
+def cartesian_to_spherical(x, y, z):
+    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
+    z = np.atleast_1d(z)
+    # Calculate x,y in spherical coordinates
+    y_sph = np.arcsin(z)
+    x_sph = np.arctan2(y, x)
+    return x_sph, y_sph
+
+
+def spherical_to_cartesian(x, y):
+    x_car = np.cos(y) * np.cos(x)
+    y_car = np.cos(y) * np.sin(x)
+    z_car = np.sin(y)
+    return x_car, y_car, z_car
+
+
+def schmidt_transform(x, y, s):
+    D = (1 - s ** 2) / (1 + s ** 2)
+    y = np.arcsin((D + np.sin(y)) / (1 + D * np.sin(y)))
+    return x, y
+
+
+def scs_transform(x, y, s, tx, ty):
+    # Convert xy to radians
+    x = x * np.pi / 180
+    y = y * np.pi / 180
+    tx = tx * np.pi / 180
+    ty = ty * np.pi / 180
+    # Calculate rotation about x, and z axes
+    x0 = np.pi
+    y0 = -np.pi/2
+    theta_x = ty - y0
+    theta_z = tx - x0
+    # Apply schmidt transform
+    x, y = schmidt_transform(x, y, s)
+    # Convert to cartesian coordinates
+    x, y, z = spherical_to_cartesian(x, y)
+    # Rotate about x axis
+    xaxis = np.array([0, 1, 0])
+    x, y, z = rotate_vectors(x, y, z, xaxis, theta_x)
+    # Rotate about z axis
+    zaxis = np.array([0, 0, 1])
+    x, y, z = rotate_vectors(x, y, z, zaxis, theta_z)
+    # Convert back to spherical coordinates
+    x, y = cartesian_to_spherical(x, y, z)
+    # Convert back to degrees and return
+    x = x * 180 / np.pi
+    y = y * 180 / np.pi
+    return x, y

--- a/gcpy/grid_stretching_transforms.py
+++ b/gcpy/grid_stretching_transforms.py
@@ -60,34 +60,3 @@ def scs_transform(x, y, s, tx, ty):
     x = x * 180 / np.pi
     y = y * 180 / np.pi
     return x, y
-
-
-def rotate_pt(x, y, k, theta):
-    v = spherical_to_cartesian(x * np.pi/180, y * np.pi/180)
-    v = rotate_vectors(*v, np.array([0, 1, 0]), np.pi/4)
-    c = cartesian_to_spherical(*v)
-    c = np.array([*c]).transpose()
-    c *= 180/np.pi
-    return c
-
-if __name__ == '__main__':
-    # print(rotate_vectors(10, 20, 30, np.array([2, 5, 1]), 1.5))
-    # print(cartesian_to_spherical(0.5, 0.3, 0.2))
-    # print(spherical_to_cartesian(0.5404195, 0.20135792))
-    # print(schmidt_transform(0.5404195, 0.20135792, 2))
-    # print(scs_transform(-145.00000000000003, -35.26438968275464, 1, -100, 30))
-    v = rotate_pt(45, 0, [0, 1, 0], np.pi/4)
-    #
-    # v = rotate_vectors(0.9396926207859084, 0.3420201433256687, 0, np.array([0, 1, 0]), np.pi/4)
-    # c = cartesian_to_spherical(*v)
-    # c = np.array([*c]).transpose()
-    # c *= 180/np.pi
-    #
-    # theta = np.pi/4
-    # ry = np.array([
-    #     [np.cos(theta), 0, np.sin(theta)],
-    #     [0, 1, 0],
-    #     [-np.sin(theta), 0, np.cos(theta)]
-    # ])
-
-    print(v)

--- a/gcpy/grid_stretching_transforms.py
+++ b/gcpy/grid_stretching_transforms.py
@@ -60,3 +60,34 @@ def scs_transform(x, y, s, tx, ty):
     x = x * 180 / np.pi
     y = y * 180 / np.pi
     return x, y
+
+
+def rotate_pt(x, y, k, theta):
+    v = spherical_to_cartesian(x * np.pi/180, y * np.pi/180)
+    v = rotate_vectors(*v, np.array([0, 1, 0]), np.pi/4)
+    c = cartesian_to_spherical(*v)
+    c = np.array([*c]).transpose()
+    c *= 180/np.pi
+    return c
+
+if __name__ == '__main__':
+    # print(rotate_vectors(10, 20, 30, np.array([2, 5, 1]), 1.5))
+    # print(cartesian_to_spherical(0.5, 0.3, 0.2))
+    # print(spherical_to_cartesian(0.5404195, 0.20135792))
+    # print(schmidt_transform(0.5404195, 0.20135792, 2))
+    # print(scs_transform(-145.00000000000003, -35.26438968275464, 1, -100, 30))
+    v = rotate_pt(45, 0, [0, 1, 0], np.pi/4)
+    #
+    # v = rotate_vectors(0.9396926207859084, 0.3420201433256687, 0, np.array([0, 1, 0]), np.pi/4)
+    # c = cartesian_to_spherical(*v)
+    # c = np.array([*c]).transpose()
+    # c *= 180/np.pi
+    #
+    # theta = np.pi/4
+    # ry = np.array([
+    #     [np.cos(theta), 0, np.sin(theta)],
+    #     [0, 1, 0],
+    #     [-np.sin(theta), 0, np.cos(theta)]
+    # ])
+
+    print(v)


### PR DESCRIPTION
This PR is for a CS->CS regridder (command line tool). This regridder uses xESMF (version 0.2.1 or greater) but it does not impose a strict requirement on gcpy (i.e., gcpy installation doesn't require xESMF, but use `python -m gcpy.cs_regrid ...` does require it). This regridder supports:
- Grid stretching (or normal cubed-sphere grids)
- Ravelled/unravelled CS formats (sometime called "the old GMAO CS format") on input/output files

This regridder is required for stretched-grid simulations because restart files have to be regridded to the stretched-grid, but some might find the general CS->CS regridder useful. Its usage looks like the following:

```
python -m gcpy.cs_regrid -i /scratch/gcchem_internal_checkpoint.20160601_0000z.nc4 -o initial_restart_file.nc --sg_params_out 3.0 261.0 36.0 --cs_res_out 60 --stacked_in --stacked_out
```

I'll resolve the [WIP] status when it's ready to be merged. The last things I have to do are
- [x] Write instructions for using `gcpy.cs_regrid`
- [x] Polish it up a bit



