### PR TITLE
Command line tool to append grid box corners to a dataset

### DIFF
--- a/gcpy/append_grid_corners.py
+++ b/gcpy/append_grid_corners.py
@@ -1,0 +1,39 @@
+import argparse
+import os.path
+
+import numpy as np
+import xarray as xr
+
+from .grid import make_grid_SG
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Append grid-box corners to file')
+    parser.add_argument('filein')
+    parser.add_argument('--sg_params',
+                        metavar='P',
+                        type=float,
+                        nargs=3,
+                        default=[1.0, 170.0, -90.0],
+                        help='input grid stretching parameters (stretch-factor, target longitude, target latitude)')
+    args = parser.parse_args()
+
+    ds = xr.open_dataset(args.filein)
+
+    csgrid, csgrid_list = make_grid_SG(
+        ds.dims['Ydim'],
+        stretch_factor=args.sg_params[0],
+        target_lon=args.sg_params[1],
+        target_lat=args.sg_params[2]
+    )
+
+    ds = ds.assign_coords({
+        'corner_lons': xr.DataArray(csgrid['lon_b'], dims=['nf', 'YCdim', 'XCdim']),
+        'corner_lats': xr.DataArray(csgrid['lat_b'], dims=['nf', 'YCdim', 'XCdim'])
+    })
+    ds.load()
+    ds.close()
+    ds.to_netcdf(args.filein)
+
+    print(ds)


### PR DESCRIPTION
This is a quick tool for appending the grid-box corners to a dataset. 

Grid-box corners are needed to plot GCHPctm data with routines like `matplotlib.pcolormesh()` (I'm talking about plotting outside of GCPy), and these corner coordinates are not available via the diagnostics. See:
- https://github.com/geoschem/GCHPctm/issues/38
- https://github.com/GEOS-ESM/MAPL/issues/541

This feature is coming in a future version of MAPL (implemented here: https://github.com/GEOS-ESM/MAPL/issues/541), and will therefore come to GCHPctm in 13.1. This tool is a temporary tool that mirrors this future functionality.

This temporary tool enables easy plotting of GCHPctm data for version 13.0. For example:

```python
import matplotlib.pyplot as plt
import cartopy.crs as ccrs # cartopy > 0.18
import xarray as xr

# Set up GeoAxes
ax = plt.axes(projection=ccrs.EqualEarth())
ax.set_global()
ax.coastlines()

# Read data and get vmin, vmax
ds = xr.open_dataset('GCHP.StateMet_avg.20170101_0030z.nc4')
da = ds['Met_PS1WET'].squeeze()
vmin = da.quantile(0.02).item()
vmax = da.quantile(0.98).item()

# Plot data
for nf in range(6):
    x = ds['corner_lons'].isel(nf=nf).values
    y = ds['corner_lats'].isel(nf=nf).values
    v = da.isel(nf=nf).values
    plt.pcolormesh(x, y, v, transform=ccrs.PlateCarree(), vmin=vmin, vmax=vmax)
```
![PS](https://user-images.githubusercontent.com/12772306/95126998-ece76b00-071c-11eb-853d-af0926e8bdaa.png)


#### Question
Should this be added to GCPy? A proper implementation of this feature will be available in GCHPctm 13.1&mdash;do we need this as a temporary measure in GCPy until then? Note that I needed this functionality for some of my own work. I thought I'd open this because I think it's useful, but I don't mind if it never gets merged.

What do you think @lizziel @WilliamDowns?