### PR TITLE
Add legacy and new filename options for GCHP diags in benchmark scripts

### DIFF
--- a/benchmark/run_1mo_benchmark.py
+++ b/benchmark/run_1mo_benchmark.py
@@ -105,6 +105,10 @@ gchp_dev_bmk_mon  = '7'
 gchp_ref_prior_to_13 = False
 gchp_dev_prior_to_13 = False
 
+# Whether GCHP files are legacy (pre-13.1) format
+gchp_ref_is_legacy=True
+gchp_dev_is_legacy=True
+
 # Name to be used for directory of output from this script
 results_dir = "BenchmarkResults"
 
@@ -327,20 +331,40 @@ gchp_dev_s_start = (str(gchp_dev_b_start[0]), str(gchp_dev_b_start[1]).zfill(2))
 gchp_dev_s_stop = (str(gchp_dev_b_stop[0]), str(gchp_dev_b_stop[1]).zfill(2))
 
 # Timestamps for files
+
+# Ref start used in diagnostic filename
 gcc_ref_date = np.datetime64("{}-{}-01T00:00:00".format(*gcc_ref_s_start))
-gchp_ref_date = np.datetime64("{}-{}-16T12:00:00".format(*gchp_ref_s_start))
+if not gchp_ref_is_legacy:
+    gchp_ref_date = np.datetime64("{}-{}-01T00:00:00".format(gchp_ref_s_start[0], gchp_ref_s_start[1]))
+else:
+    gchp_ref_date = np.datetime64("{}-{}-16T12:00:00".format(gchp_ref_s_start[0], gchp_ref_s_start[1]))
+
+# Ref end used in restart filename)
 gcc_end_ref_date = np.datetime64("{}-{}-01T00:00:00".format(*gcc_ref_s_stop))
 gchp_end_ref_date = np.datetime64("{}-{}-01T00:00:00".format(*gchp_ref_s_stop))
+
+# Dev start used in diagnostic filename
 gcc_dev_date = np.datetime64("{}-{}-01T00:00:00".format(*gcc_dev_s_start))
-gchp_dev_date = np.datetime64("{}-{}-16T12:00:00".format(*gchp_dev_s_start))
+if not gchp_dev_is_legacy:
+    gchp_dev_date = np.datetime64("{}-{}-01T00:00:00".format(gchp_dev_s_start[0], gchp_dev_s_start[1]))
+else:
+    gchp_dev_date = np.datetime64("{}-{}-16T12:00:00".format(gchp_dev_s_start[0], gchp_dev_s_start[1]))
+
+# Dev end used in restart filename
 gcc_end_dev_date = np.datetime64("{}-{}-01T00:00:00".format(*gcc_dev_s_stop))
 gchp_end_dev_date = np.datetime64("{}-{}-01T00:00:00".format(*gchp_dev_s_stop))
 
 # Seconds per month
 gcc_ref_sec_in_bmk_month = (gcc_end_ref_date  - gcc_ref_date).astype("float64")
-gchp_ref_sec_in_bmk_month = (gchp_end_ref_date - gchp_ref_date).astype("float64") * 2
+gchp_ref_sec_in_bmk_month = (gchp_end_ref_date - gchp_ref_date).astype("float64")
 gcc_dev_sec_in_bmk_month = (gcc_end_dev_date  - gcc_dev_date).astype("float64")
-gchp_dev_sec_in_bmk_month = (gchp_end_dev_date - gchp_dev_date).astype("float64") * 2
+gchp_dev_sec_in_bmk_month = (gchp_end_dev_date - gchp_dev_date).astype("float64")
+
+# Double gchp sec/month if mid-point timestamp in filename (legacy format)
+if gchp_ref_is_legacy:
+    gchp_ref_sec_in_bmk_month = gchp_ref_sec_in_bmk_month * 2
+if gchp_dev_is_legacy:
+    gchp_dev_sec_in_bmk_month = gchp_dev_sec_in_bmk_month * 2
 
 # ======================================================================
 # Significant difference filenames
@@ -767,7 +791,7 @@ if gchp_vs_gcc:
             calendar.month_abbr[gchp_dev_b_start[1]] + gchp_dev_s_start[0]
 
     # ==================================================================
-    # GCC vs GCC filepaths for StateMet collection data
+    # GCHP vs GCC filepaths for StateMet collection data
     # ==================================================================
     refmet = get_filepath(
         gchp_vs_gcc_refdir,
@@ -778,7 +802,8 @@ if gchp_vs_gcc:
         gchp_vs_gcc_devdir,
         gchp_metname(gchp_dev_prior_to_13),
         gchp_dev_date,
-        is_gchp=True
+        is_gchp=True,
+        gchp_format_is_legacy=gchp_dev_is_legacy
     )
 
     # ==================================================================
@@ -797,7 +822,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "SpeciesConc",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -832,7 +858,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "Emissions",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create emissions plots
@@ -866,7 +893,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "Emissions",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -899,7 +927,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "JValues",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -931,7 +960,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "Aerosols",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -963,7 +993,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devrst,
             "Restart",
             gchp_end_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create tables
@@ -993,7 +1024,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "Budget",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1032,7 +1064,8 @@ if gchp_vs_gcc:
             gchp_vs_gcc_devdir,
             "Metrics",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create table
@@ -1086,13 +1119,15 @@ if gchp_vs_gchp:
         gchp_vs_gchp_refdir,
         gchp_metname(gchp_ref_prior_to_13),
         gchp_ref_date,
-        is_gchp=True
+        is_gchp=True,
+        gchp_format_is_legacy=gchp_ref_is_legacy
     )
     devmet = get_filepath(
         gchp_vs_gchp_devdir,
         gchp_metname(gchp_dev_prior_to_13),
         gchp_dev_date,
-        is_gchp=True
+        is_gchp=True,
+        gchp_format_is_legacy=gchp_dev_is_legacy
     )
 
     # ==================================================================
@@ -1106,13 +1141,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "SpeciesConc",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "SpeciesConc",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1142,13 +1179,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "Emissions",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "Emissions",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1177,13 +1216,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "Emissions",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "Emissions",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create tables
@@ -1212,13 +1253,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "JValues",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "JValues",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1245,13 +1288,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "Aerosols",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "Aerosols",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1278,13 +1323,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refrst,
             "Restart",
             gchp_end_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devrst,
             "Restart",
             gchp_end_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create tables
@@ -1309,13 +1356,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "Budget",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "Budget",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create tables
@@ -1351,13 +1400,15 @@ if gchp_vs_gchp:
             gchp_vs_gchp_refdir,
             "Metrics",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         dev = get_filepath(
             gchp_vs_gchp_devdir,
             "Metrics",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create table
@@ -1400,13 +1451,15 @@ if gchp_vs_gcc_diff_of_diffs:
             gchp_vs_gchp_refdir,
             "SpeciesConc",
             gchp_ref_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_ref_is_legacy
         )
         gchp_dev = get_filepath(
             gchp_vs_gchp_devdir,
             "SpeciesConc",
             gchp_dev_date,
-            is_gchp=True
+            is_gchp=True,
+            gchp_format_is_legacy=gchp_dev_is_legacy
         )
 
         # Create diff-of-diff plots for species concentrations

--- a/benchmark/run_1yr_fullchem_benchmark.py
+++ b/benchmark/run_1yr_fullchem_benchmark.py
@@ -117,6 +117,10 @@ gchp_dev_res = 'c48'
 gchp_ref_prior_to_13 = False
 gchp_dev_prior_to_13 = False
 
+# Whether GCHP files are legacy (pre-13.1) format
+gchp_ref_is_legacy=True
+gchp_dev_is_legacy=True
+
 # ======================================================================
 # Specify if this is a gcpy test validation run
 # ======================================================================
@@ -291,6 +295,13 @@ def gchp_metname(prior_to_13):
 # Month/year strings for use in table subdirectories (e.g. Jan2016)
 bmk_mon_yr_strs_ref = [v + bmk_year_ref for v in bmk_mon_strs]
 
+# Get days per month and seconds per month for ref
+sec_per_month_ref = np.zeros(12)
+days_per_month_ref = np.zeros(12)
+for t in range(12):
+    days_per_month_ref[t] = monthrange(int(bmk_year_ref), t + 1)[1]
+    sec_per_month_ref[t] = days_per_month_ref[t] * 86400.0
+
 # Get all months array of start datetimes for benchmark year
 bmk_start_ref = np.datetime64(bmk_year_ref + "-01-01")
 bmk_end_ref = np.datetime64("{}-01-01".format(int(bmk_year_ref)+1))
@@ -298,23 +309,20 @@ all_months_ref = np.arange(bmk_start_ref,
                            bmk_end_ref,
                            step=np.timedelta64(1, "M"),
                            dtype="datetime64[M]")
+all_months_gchp_ref = all_months_ref
 
-# Get all months array of mid-point datetime per month for benchmark year,
-# and # sec and # days per month
-# NOTE: GCHP time-averaged files have time in the middle of the month
-sec_per_month_ref = np.zeros(12)
-days_per_month_ref = np.zeros(12)
-all_months_mid_ref = np.zeros(12, dtype="datetime64[h]")
-for t in range(12):
-    days_per_month_ref[t] = monthrange(int(bmk_year_ref), t + 1)[1]
-    sec_per_month_ref[t] = days_per_month_ref[t] * 86400.0
-    middle_hr = int(days_per_month_ref[t] * 24 / 2)
-    delta = np.timedelta64(middle_hr, 'h')
-    all_months_mid_ref[t] = all_months_ref[t].astype("datetime64[h]") + delta
+# Reset all months datetime array if GCHP ref is legacy filename format.
+# Legacy format uses time-averaging period mid-point not start.
+if gchp_ref_is_legacy:
+    all_months_gchp_ref = np.zeros(12, dtype="datetime64[h]")
+    for t in range(12):
+        middle_hr = int(days_per_month_ref[t] * 24 / 2)
+        delta = np.timedelta64(middle_hr, 'h')
+        all_months_gchp_ref[t] = all_months_ref[t].astype("datetime64[h]") + delta
 
-# Get subset of month datetimes for only benchmark months
+# Get subset of month datetimes and seconds per month for only benchmark months
 bmk_mons_ref = all_months_ref[bmk_mon_inds]
-bmk_mons_mid_ref = all_months_mid_ref[bmk_mon_inds]
+bmk_mons_gchp_ref = all_months_gchp_ref[bmk_mon_inds]
 bmk_sec_per_month_ref = sec_per_month_ref[bmk_mon_inds]
 
 # =====================================================================
@@ -324,6 +332,13 @@ bmk_sec_per_month_ref = sec_per_month_ref[bmk_mon_inds]
 # Month/year strings for use in table subdirectories (e.g. Jan2016)
 bmk_mon_yr_strs_dev = [v + bmk_year_dev for v in bmk_mon_strs]
 
+# Get days per month and seconds per month for dev
+sec_per_month_dev = np.zeros(12)
+days_per_month_dev = np.zeros(12)
+for t in range(12):
+    days_per_month_dev[t] = monthrange(int(bmk_year_dev), t + 1)[1]
+    sec_per_month_dev[t] = days_per_month_dev[t] * 86400.0
+
 # Get all months array of start datetimes for benchmark year
 bmk_start_dev = np.datetime64(bmk_year_dev + "-01-01")
 bmk_end_dev = np.datetime64("{}-01-01".format(int(bmk_year_dev)+1))
@@ -331,23 +346,20 @@ all_months_dev = np.arange(bmk_start_dev,
                            bmk_end_dev,
                            step=np.timedelta64(1, "M"),
                            dtype="datetime64[M]")
+all_months_gchp_dev = all_months_dev
 
-# Get all months array of mid-point datetime per month for benchmark year,
-# and # sec and # days per month
-# NOTE: GCHP time-averaged files have time in the middle of the month
-sec_per_month_dev = np.zeros(12)
-days_per_month_dev = np.zeros(12)
-all_months_mid_dev = np.zeros(12, dtype="datetime64[h]")
-for t in range(12):
-    days_per_month_dev[t] = monthrange(int(bmk_year_dev), t + 1)[1]
-    sec_per_month_dev[t] = days_per_month_dev[t] * 86400.0
-    middle_hr = int(days_per_month_dev[t] * 24 / 2)
-    delta = np.timedelta64(middle_hr, 'h')
-    all_months_mid_dev[t] = all_months_dev[t].astype("datetime64[h]") + delta
+# Reset all months datetime array if GCHP dev is legacy filename format.
+# Legacy format uses time-averaging period mid-point not start.
+if gchp_dev_is_legacy:
+    all_months_gchp_dev = np.zeros(12, dtype="datetime64[h]")
+    for t in range(12):
+        middle_hr = int(days_per_month_dev[t] * 24 / 2)
+        delta = np.timedelta64(middle_hr, 'h')
+        all_months_gchp_dev[t] = all_months_dev[t].astype("datetime64[h]") + delta
 
-# Get subset of month datetimes for only benchmark months
+# Get subset of month datetimes and seconds per month for only benchmark months
 bmk_mons_dev = all_months_dev[bmk_mon_inds]
-bmk_mons_mid_dev = all_months_mid_dev[bmk_mon_inds]
+bmk_mons_gchp_dev = all_months_gchp_dev[bmk_mon_inds]
 bmk_sec_per_month_dev = sec_per_month_dev[bmk_mon_inds]
 
 # ======================================================================
@@ -873,8 +885,9 @@ if gchp_vs_gcc:
     devmet = get_filepaths(
         gchp_vs_gcc_devdir,
         gchp_metname(gchp_dev_prior_to_13),
-        all_months_mid_dev,
-        is_gchp=True
+        all_months_gchp_dev,
+        is_gchp=True,
+        is_legacy_gchp_format=gchp_dev_is_legacy
     )[0]
 
     # ==================================================================
@@ -896,8 +909,9 @@ if gchp_vs_gcc:
         dev = get_filepaths(
             gchp_vs_gcc_devdir,
             "SpeciesConc",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create plots
@@ -960,8 +974,9 @@ if gchp_vs_gcc:
         dev = get_filepaths(
             gchp_vs_gcc_devdir,
             "Emissions",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create plots
@@ -1014,8 +1029,9 @@ if gchp_vs_gcc:
         dev = get_filepaths(
             gchp_vs_gcc_devdir,
             "Emissions",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create emissions table that spans entire year
@@ -1051,8 +1067,9 @@ if gchp_vs_gcc:
         dev = get_filepaths(
             gchp_vs_gcc_devdir,
             "JValues",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create plots
@@ -1105,8 +1122,10 @@ if gchp_vs_gcc:
         dev = get_filepaths(
             gchp_vs_gcc_devdir,
             "Aerosols",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
+
         )[0]
 
         # Create plots
@@ -1161,7 +1180,8 @@ if gchp_vs_gcc:
                 gchp_vs_gcc_devrstdir,
                 "Restart",
                 bmk_mons_dev[m],
-                is_gchp=True
+                is_gchp=True,
+                is_legacy_gchp_format=gchp_dev_is_legacy
             )
 
             # use initial restart if no checkpoint present (intended for
@@ -1177,7 +1197,8 @@ if gchp_vs_gcc:
                     gchp_vs_gcc_devrstdir,
                     "Restart",
                     bmk_mons_dev[m+1],
-                    is_gchp=True
+                    is_gchp=True,
+                    is_legacy_gchp_format=gchp_dev_is_legacy
                 )
 
             # Create tables
@@ -1217,8 +1238,9 @@ if gchp_vs_gcc:
             devpath = get_filepath(
                 gchp_vs_gcc_devdir,
                 "Budget",
-                bmk_mons_mid_dev[m],
-                is_gchp=True
+                bmk_mons_gchp_dev[m],
+                is_gchp=True,
+                is_legacy_gchp_format=gchp_dev_is_legacy
             )
 
             # Create tables
@@ -1255,14 +1277,16 @@ if gchp_vs_gcc:
         devaero = get_filepaths(
             gchp_vs_gcc_devdir,
             "Aerosols",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
         devspc = get_filepaths(
             gchp_vs_gcc_devdir,
             "SpeciesConc",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create tables
@@ -1277,7 +1301,7 @@ if gchp_vs_gcc:
             dst=gchp_vs_gcc_tablesdir,
             overwrite=True,
             spcdb_dir=spcdb_dir,
-            is_gchp=True
+            is_gchp=True,
         )
 
     # Comment out the budget tables until we are sure that GCHP
@@ -1326,8 +1350,9 @@ if gchp_vs_gcc:
         dev = get_filepaths(
             gchp_vs_gcc_devdir,
             "Metrics",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create table
@@ -1358,14 +1383,16 @@ if gchp_vs_gchp:
     refmet = get_filepaths(
         gchp_vs_gchp_refdir,
         gchp_metname(gchp_ref_prior_to_13),
-        all_months_mid_ref,
-        is_gchp=True
+        all_months_gchp_ref,
+        is_gchp=True,
+        is_legacy_gchp_format=gchp_ref_is_legacy
     )[0]
     devmet = get_filepaths(
         gchp_vs_gcc_devdir,
         gchp_metname(gchp_dev_prior_to_13),
-        all_months_mid_dev,
-        is_gchp=True
+        all_months_gchp_dev,
+        is_gchp=True,
+        is_legacy_gchp_format=gchp_dev_is_legacy
     )[0]
 
     # ==================================================================
@@ -1382,14 +1409,16 @@ if gchp_vs_gchp:
         ref = get_filepaths(
             gchp_vs_gchp_refdir,
             "SpeciesConc",
-            all_months_mid_ref,
-            is_gchp=True
+            all_months_gchp_ref,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_ref_is_legacy
         )
         dev = get_filepaths(
             gchp_vs_gchp_devdir,
             col,
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1445,14 +1474,16 @@ if gchp_vs_gchp:
         ref = get_filepaths(
             gchp_vs_gchp_refdir,
             "Emissions",
-            all_months_mid_ref,
-            is_gchp=True
+            all_months_gchp_ref,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_ref_is_legacy
         )[0]
         dev = get_filepaths(
             gchp_vs_gchp_devdir,
             "Emissions",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create plots
@@ -1500,14 +1531,16 @@ if gchp_vs_gchp:
         ref = get_filepaths(
             gchp_vs_gchp_refdir,
             "Emissions",
-            all_months_mid_ref,
-            is_gchp=True
+            all_months_gchp_ref,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_ref_is_legacy
         )
         dev = get_filepaths(
             gchp_vs_gchp_devdir,
             "Emissions",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )
 
         # Create table
@@ -1539,14 +1572,16 @@ if gchp_vs_gchp:
         ref = get_filepaths(
             gchp_vs_gchp_refdir,
             "JValues",
-            all_months_mid_ref,
-            is_gchp=True
+            all_months_gchp_ref,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_ref_is_legacy
         )
         dev = get_filepaths(
             gchp_vs_gchp_devdir,
             "JValues",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1593,14 +1628,16 @@ if gchp_vs_gchp:
         ref = get_filepaths(
             gchp_vs_gchp_refdir,
             "Aerosols",
-            all_months_mid_ref,
-            is_gchp=True
+            all_months_gchp_ref,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_ref_is_legacy
         )
         dev = get_filepaths(
             gchp_vs_gchp_devdir,
             "Aerosols",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )
 
         # Create plots
@@ -1651,7 +1688,8 @@ if gchp_vs_gchp:
                 gchp_vs_gchp_refrstdir,
                 "Restart",
                 bmk_mons_ref[m],
-                is_gchp=True
+                is_gchp=True,
+                is_legacy_gchp_format=gchp_ref_is_legacy
             )
 
             # Use initial checkpoint if Ref restart is not present
@@ -1665,7 +1703,8 @@ if gchp_vs_gchp:
                     gchp_vs_gchp_refrstdir,
                     "Restart",
                     bmk_mons_ref[m+1],
-                    is_gchp=True
+                    is_gchp=True,
+                    is_legacy_gchp_format=gchp_ref_is_legacy
                 )
 
             # Dev filepaths
@@ -1673,7 +1712,8 @@ if gchp_vs_gchp:
                 gchp_vs_gchp_devrstdir,
                 "Restart",
                 bmk_mons_dev[m],
-                is_gchp=True
+                is_gchp=True,
+                is_legacy_gchp_format=gchp_dev_is_legacy
             )
 
             # Use initial checkpoint if Dev restart is not present
@@ -1687,7 +1727,8 @@ if gchp_vs_gchp:
                     gchp_vs_gchp_devrstdir,
                     "Restart",
                     bmk_mons_dev[m+1],
-                    is_gchp=True
+                    is_gchp=True,
+                    is_legacy_gchp_format=gchp_dev_is_legacy
                 )
 
             # Create tables
@@ -1725,14 +1766,16 @@ if gchp_vs_gchp:
             refpath = get_filepath(
                 gchp_vs_gchp_refdir,
                 "Budget",
-                bmk_mons_mid_ref[m],
-                is_gchp=True
+                bmk_mons_gchp_ref[m],
+                is_gchp=True,
+                is_legacy_gchp_format=gchp_ref_is_legacy
             )
             devpath = get_filepath(
                 gchp_vs_gchp_devdir,
                 "Budget",
-                bmk_mons_mid_dev[m],
-                is_gchp=True
+                bmk_mons_gchp_dev[m],
+                is_gchp=True,
+                is_legacy_gchp_format=gchp_dev_is_legacy
             )
 
             # Compute tables
@@ -1796,14 +1839,16 @@ if gchp_vs_gchp:
         ref = get_filepaths(
             gchp_vs_gchp_refdir,
             "Metrics",
-            all_months_mid_ref,
-            is_gchp=True
+            all_months_gchp_ref,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_ref_is_legacy
         )[0]
         dev = get_filepaths(
             gchp_vs_gchp_devdir,
             "Metrics",
-            all_months_mid_dev,
-            is_gchp=True
+            all_months_gchp_dev,
+            is_gchp=True,
+            is_legacy_gchp_format=gchp_dev_is_legacy
         )[0]
 
         # Create the OH Metrics table

--- a/gcpy/budget_tt.py
+++ b/gcpy/budget_tt.py
@@ -127,7 +127,7 @@ class _GlobVars:
         WetLossLS = join(self.devdir,
                          "*.WetLossLS.{}*.nc4".format(self.y0_str))
         GCHPEmiss = join(self.devdir,
-                         "GCHP.Emissions.{}*.nc4".format(self.y0_str))
+                         "*.Emissions.{}*.nc4".format(self.y0_str))
 
         # ------------------------------
         # Read data collections

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -1633,7 +1633,8 @@ def get_filepath(
         datadir,
         col,
         date,
-        is_gchp=False
+        is_gchp=False,
+        gchp_format_is_legacy=False
 ):
     """
     Routine to return file path for a given GEOS-Chem "Classic"
@@ -1653,6 +1654,11 @@ def get_filepath(
             Set this switch to True to obtain file pathnames to
             GCHP diagnostic data files. If False, assumes GEOS-Chem "Classic"
 
+        gchp_format_is_legacy: bool
+            Set this switch to True to obtain GCHP file pathnames of
+            the legacy format for diagnostics, which do not match GC-Classic
+            filenames. Set to False to use same format as GC-Classic.
+
     Returns:
         path: str
             Pathname for the specified collection and date.
@@ -1661,6 +1667,7 @@ def get_filepath(
     # Set filename template, extension, separator, and date string from
     # the collection, date, and data directory arguments
     separator = "_"
+    extension = "z.nc4"
     date_str = np.datetime_as_string(date, unit="m")
     if is_gchp:
         if "Restart" in col:
@@ -1669,8 +1676,10 @@ def get_filepath(
             extension = ".nc4"
             date_str = np.datetime_as_string(date, unit="s")
         else:
-            file_tmpl = os.path.join(datadir, "GCHP.{}.".format(col))
-            extension = "z.nc4"
+            if gchp_format_is_legacy:
+                file_tmpl = os.path.join(datadir, "GCHP.{}.".format(col))
+            else:
+                file_tmpl = os.path.join(datadir, "GEOSChem.{}.".format(col))
     else:
         if "Emissions" in col:
             file_tmpl = os.path.join(datadir, "HEMCO_diagnostics.")
@@ -1678,7 +1687,6 @@ def get_filepath(
             separator = ""
         else:
             file_tmpl = os.path.join(datadir, "GEOSChem.{}.".format(col))
-            extension = "z.nc4"
     if isinstance(date_str, np.str_):
         date_str = str(date_str)
     date_str = date_str.replace("T", separator)
@@ -1694,7 +1702,8 @@ def get_filepaths(
         datadir,
         collections,
         dates,
-        is_gchp=False
+        is_gchp=False,
+        gchp_format_is_legacy=False
 ):
     """
     Routine to return filepaths for a given GEOS-Chem "Classic"
@@ -1713,6 +1722,11 @@ def get_filepaths(
         is_gchp: bool
             Set this switch to True to obtain file pathnames to
             GCHP diagnostic data files. If False, assumes GEOS-Chem "Classic"
+
+        gchp_format_is_legacy: bool
+            Set this switch to True to obtain GCHP file pathnames of
+            the legacy format for diagnostics, which do not match GC-Classic
+            filenames. Set to False to use same format as GC-Classic.
 
     Returns:
         paths: 2D list of str
@@ -1738,6 +1752,8 @@ def get_filepaths(
     # ==================================================================
     for c, collection in enumerate(collections):
 
+        separator = "_"
+        extension = "z.nc4"
         if is_gchp:
             # ---------------------------------------
             # Get the file path template for GCHP
@@ -1745,13 +1761,13 @@ def get_filepaths(
             if "Restart" in collection:
                 file_tmpl = os.path.join(datadir,
                                          "gcchem_internal_checkpoint.restart.")
-                separator = "_"
                 extension = ".nc4"
             else:
-                file_tmpl = os.path.join(datadir,
-                                         "GCHP.{}.".format(collection))
-                separator = "_"
-                extension = "z.nc4"
+                if gchp_format_is_legacy:
+                    file_tmpl = os.path.join(datadir,
+                                             "GCHP.{}.".format(collection))
+                else:
+                    file_tmpl = os.path.join(datadir, "GEOSChem.{}.".format(collection))
         else:
             # ---------------------------------------
             # Get the file path template for GCC
@@ -1764,8 +1780,6 @@ def get_filepaths(
             else:
                 file_tmpl = os.path.join(datadir,
                                          "GEOSChem.{}.".format(collection))
-                separator = "_"
-                extension = "z.nc4"
 
         # --------------------------------------------
         # Create a list of files for each date/time


### PR DESCRIPTION
This PR is necessary following merge of PR https://github.com/geoschem/geos-chem/pull/709 and inclusion in GCHP 13.1. That update changes the GCHP diagnostics file format to match GEOS-Chem Classic. This update in GCPy allows using either the new or legacy file formats for benchmarking. Set which is used for ref and dev at top of the benchmark scripts via logical toggles.