### PR TITLE
Designate netCDF4 engine for xarray in SG regrid

### DIFF
--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -132,7 +132,7 @@ def file_regrid(
                 oface_files[oface],
                 format='NETCDF4_CLASSIC'
             )
-        ds_out=xr.open_mfdataset(oface_files, combine='by_coords', concat_dim='F')
+        ds_out=xr.open_mfdataset(oface_files, combine='by_coords', concat_dim='F',engine='netcdf4')
         # Put regridded dataset back into a familiar format
         ds_out = ds_out.rename({
             'y': 'Y',


### PR DESCRIPTION
When recombining the 6 files during a regrid for the stretched grid, xarray (0.18.0) was unable to determine which engine to use and failed. This hotfix forces it to use the netCDF4 engine, which fixes the issue.