### PR TITLE
Updates for new GCHP restart file format

### DIFF
--- a/benchmark/1mo_benchmark.yml
+++ b/benchmark/1mo_benchmark.yml
@@ -1,4 +1,4 @@
----
+&---
 # =====================================================================
 # Benchmark configuration file (**EDIT AS NEEDED**)
 # customize in the following manner:
@@ -33,7 +33,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-07-01T00:00:00"
       bmk_end: "2019-08-01T00:00:00"
-      is_legacy: False # Whether GCHP files are legacy (pre-13.1) format
+      is_pre_13.1: False # Whether GCHP files are legacy (pre-13.1) format
+      is_pre_14.0: True # Whether GCHP files are legacy (pre-14.0) format
   dev:
     gcc:
       version: GCC_dev 
@@ -47,7 +48,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-07-01T00:00:00" 
       bmk_end: "2019-08-01T00:00:00"
-      is_legacy: False
+      is_pre_13.1: False
+      is_pre_14.0: True
 
 options:
   bmk_type: FullChemBenchmark

--- a/benchmark/1yr_fullchem_benchmark.yml
+++ b/benchmark/1yr_fullchem_benchmark.yml
@@ -30,7 +30,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_legacy: True
+      is_pre_13.1: False
+      is_pre_14.0: True
       resolution: c48 # GCHP initial restart resolution (for mass tables)
   dev:
     gcc:
@@ -45,7 +46,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_legacy: False
+      is_pre_13.1: False
+      is_pre_14.0: False
       resolution: c48
 
 options:

--- a/benchmark/1yr_tt_benchmark.yml
+++ b/benchmark/1yr_tt_benchmark.yml
@@ -30,7 +30,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_legacy: True
+      is_pre_13.1: False
+      is_pre_14.0: True
   dev:
     gcc:
       version: GCC_dev 
@@ -44,7 +45,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_legacy: False
+      is_pre_13.1: False
+      is_pre_14.0: False
 
 options:
   bmk_type: TransportTracersBenchmark

--- a/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -57,6 +57,7 @@ import gcpy.ste_flux as ste
 import gcpy.oh_metrics as oh
 import gcpy.budget_ox as ox
 from gcpy import benchmark as bmk
+from .grid import get_input_res
 
 
 # Tell matplotlib not to look for an X-window
@@ -282,7 +283,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
 
     # Reset all months datetime array if GCHP ref is legacy filename format.
     # Legacy format uses time-averaging period mid-point not start.
-    if config["data"]["ref"]["gchp"]["is_legacy"]:
+    if config["data"]["ref"]["gchp"]["is_pre_13.1"]:
         all_months_gchp_ref = np.zeros(12, dtype="datetime64[h]")
         for t in range(12):
             middle_hr = int(days_per_month_ref[t] * 24 / 2)
@@ -318,7 +319,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
 
     # Reset all months datetime array if GCHP dev is legacy filename format.
     # Legacy format uses time-averaging period mid-point not start.
-    if config["data"]["dev"]["gchp"]["is_legacy"]:
+    if config["data"]["dev"]["gchp"]["is_pre_13.1"]:
         all_months_gchp_dev = np.zeros(12, dtype="datetime64[h]")
         for t in range(12):
             middle_hr = int(days_per_month_dev[t] * 24 / 2)
@@ -780,8 +781,12 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             gchp_metname,
             all_months_gchp_dev,
             is_gchp=True,
-            gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+            gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
         )[0]
+
+        # Get GCHP grid resolution from met collection file
+        ds_devmet = xr.open_dataset(devmet[0])
+        gchp_dev_res = str(get_input_res(ds_devmet)[0])
 
         # ==================================================================
         # GCHP vs GCC Concentration plots
@@ -800,7 +805,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "SpeciesConc",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -864,7 +869,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Emissions",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -927,7 +932,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Emissions",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create emissions table that spans entire year
@@ -961,7 +966,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "JValues",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -1016,7 +1021,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Aerosols",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -1074,7 +1079,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Restart",
                     bmk_mons_dev[m],
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                    gchp_res=gchp_dev_res,
+                    gchp_is_pre_14.0=config["data"]["dev"]["gchp"]["is_pre_14.0"],
                 )
 
                 # use initial restart if no checkpoint present (intended for
@@ -1093,9 +1099,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "Restart",
                         bmk_mons_dev[m + 1],
                         is_gchp=True,
-                        gchp_format_is_legacy=config["data"]["dev"]["gchp"][
-                            "is_legacy"
-                        ],
+                        gchp_res=gchp_dev_res,
+                        gchp_is_pre_14.0=config["data"]["dev"]["gchp"]["is_pre_14.0"],
                     )
 
                 # Create tables
@@ -1134,7 +1139,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Budget",
                     bmk_mons_gchp_dev[m],
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                    gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
                 )
 
                 # Create tables
@@ -1174,14 +1179,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Aerosols",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
             devspc = get_filepaths(
                 gchp_vs_gcc_devdir,
                 "SpeciesConc",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create tables
@@ -1241,7 +1246,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Metrics",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create table
@@ -1274,15 +1279,21 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             gchp_metname,
             all_months_gchp_ref,
             is_gchp=True,
-            gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+            gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
         )[0]
         devmet = get_filepaths(
             gchp_vs_gcc_devdir,
             gchp_metname,
             all_months_gchp_dev,
             is_gchp=True,
-            gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+            gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
         )[0]
+
+        # Get GCHP grid resolutions from met collection file
+        ds_refmet = xr.open_dataset(refmet[0])
+        ds_devmet = xr.open_dataset(devmet[0])
+        gchp_ref_res = str(get_input_res(ds_refmet)[0])
+        gchp_dev_res = str(get_input_res(ds_devmet)[0])
 
         # ==================================================================
         # GCHP vs GCHP species concentration plots
@@ -1300,14 +1311,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "SpeciesConc",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "SpeciesConc",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -1373,14 +1384,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Emissions",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "Emissions",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -1442,14 +1453,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Emissions",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "Emissions",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create table
@@ -1483,14 +1494,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "JValues",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "JValues",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -1544,14 +1555,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Aerosols",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "Aerosols",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -1606,7 +1617,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Restart",
                     bmk_mons_ref[m],
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                    gchp_res=gchp_ref_res,
+                    gchp_is_pre_14.0=config["data"]["ref"]["gchp"]["is_pre_14.0"],
                 )
 
                 # Use initial checkpoint if Ref restart is not present
@@ -1623,9 +1635,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "Restart",
                         bmk_mons_ref[m + 1],
                         is_gchp=True,
-                        gchp_format_is_legacy=config["data"]["ref"]["gchp"][
-                            "is_legacy"
-                        ],
+                        gchp_res=gchp_ref_res,
+                        gchp_is_pre_14.0=config["data"]["ref"]["gchp"]["is_pre_14.0"],
                     )
 
                 # Dev filepaths
@@ -1634,7 +1645,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Restart",
                     bmk_mons_dev[m],
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                    gchp_res=gchp_dev_res,
+                    gchp_is_pre_14.0=config["data"]["dev"]["gchp"]["is_pre_14.0"],
                 )
 
                 # Use initial checkpoint if Dev restart is not present
@@ -1651,9 +1663,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "Restart",
                         bmk_mons_dev[m + 1],
                         is_gchp=True,
-                        gchp_format_is_legacy=config["data"]["dev"]["gchp"][
-                            "is_legacy"
-                        ],
+                        gchp_res=gchp_dev_res,
+                        gchp_is_pre_14.0=config["data"]["dev"]["gchp"]["is_pre_14.0"],
                     )
 
                 # Create tables
@@ -1694,14 +1705,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Budget",
                     bmk_mons_gchp_ref[m],
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                    gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
                 )
                 devpath = get_filepath(
                     gchp_vs_gchp_devdir,
                     "Budget",
                     bmk_mons_gchp_dev[m],
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                    gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
                 )
 
                 # Compute tables
@@ -1742,14 +1753,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Aerosols",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"]
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"]
             )[0]
             devspc = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "SpeciesConc",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"]
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"]
             )[0]
 
             # Create tables
@@ -1797,14 +1808,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Metrics",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "Metrics",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create the OH Metrics table

--- a/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/benchmark/modules/run_1yr_tt_benchmark.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 """
 run_1yr_benchmark.py: Driver script for creating benchmark plots and testing
@@ -54,6 +55,7 @@ from gcpy.util import get_filepaths, read_config_file
 from gcpy import benchmark as bmk
 import gcpy.budget_tt as ttbdg
 import gcpy.ste_flux as ste
+from .grid import get_input_res
 
 # Tell matplotlib not to look for an X-window
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
@@ -264,7 +266,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
 
     # Overwrite all_months_gchp_ref if GCHP ref is legacy filename format.
     # Legacy format uses time-averaging period mid-point not start.
-    if config["data"]["ref"]["gchp"]["is_legacy"]:
+    if config["data"]["ref"]["gchp"]["is_pre_13.1"]:
         all_months_gchp_ref = np.zeros(12, dtype="datetime64[h]")
         for t in range(12):
             days_in_mon = monthrange(int(bmk_year_ref), t + 1)[1]
@@ -295,7 +297,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
 
     # Overwrite all_months_gchp_ref if GCHP ref is legacy filename format.
     # Legacy format uses time-averaging period mid-point not start.
-    if config["data"]["dev"]["gchp"]["is_legacy"]:
+    if config["data"]["dev"]["gchp"]["is_pre_13.1"]:
         sec_per_yr_dev = 0
         all_months_gchp_dev = np.zeros(12, dtype="datetime64[h]")
         for t in range(12):
@@ -537,8 +539,12 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             gchp_metname,
             all_months_gchp_dev,
             is_gchp=True,
-            gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+            gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
         )[0]
+
+        # Get GCHP grid resolution from met collection file
+        ds_devmet = xr.open_dataset(devmet[0])
+        gchp_dev_res = str(get_input_res(ds_devmet)[0])
 
         # ==================================================================
         # GCHP vs GCC species concentration plots
@@ -560,7 +566,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "SpeciesConc",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create plots
@@ -625,7 +631,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     col,
                     all_months_gchp_dev,
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                    gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
                 )[0]
 
                 # Create plots
@@ -698,7 +704,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 col,
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Make operations budget table
@@ -735,15 +741,21 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             gchp_metname,
             all_months_gchp_ref,
             is_gchp=True,
-            gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+            gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
         )[0]
         devmet = get_filepaths(
             gchp_vs_gchp_devdir,
             gchp_metname,
             all_months_gchp_dev,
             is_gchp=True,
-            gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+            gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
         )[0]
+
+        # Get GCHP grid resolutions from met collection file
+        ds_refmet = xr.open_dataset(refmet[0])
+        ds_devmet = xr.open_dataset(devmet[0])
+        gchp_ref_res = str(get_input_res(ds_refmet)[0])
+        gchp_dev_res = str(get_input_res(ds_devmet)[0])
 
         # ==================================================================
         # GCHP vs GCHP species concentration plots
@@ -764,14 +776,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "SpeciesConc",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             dev = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "SpeciesConc",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Make concentration plots
@@ -835,14 +847,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     col,
                     all_months_gchp_ref,
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                    gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
                 )[0]
                 dev = get_filepaths(
                     gchp_vs_gchp_devdir,
                     col,
                     all_months_gchp_dev,
                     is_gchp=True,
-                    gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                    gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
                 )[0]
 
                 # Create plots
@@ -914,14 +926,14 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Budget",
                 all_months_gchp_ref,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["ref"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["ref"]["gchp"]["is_pre_13.1"],
             )[0]
             devs = get_filepaths(
                 gchp_vs_gchp_devdir,
                 "Budget",
                 all_months_gchp_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
             )[0]
 
             # Create table
@@ -960,9 +972,11 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             print("\n%%% Creating GCC dev mass conservation table %%%")
 
             # Filepaths
-            datafiles = get_filepaths(gcc_vs_gcc_devrstdir, "Restart", all_months_dev)[
-                0
-            ]
+            datafiles = get_filepaths(
+                gcc_vs_gcc_devrstdir,
+                "Restart",
+                all_months_dev
+            )[0]
 
             # Pick output folder
             if config["options"]["comparisons"]["gchp_vs_gcc"]["run"]:
@@ -994,7 +1008,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 "Restart",
                 all_months_dev,
                 is_gchp=True,
-                gchp_format_is_legacy=config["data"]["dev"]["gchp"]["is_legacy"],
+                gchp_res=gchp_dev_res,
+                gchp_is_pre_13.1=config["data"]["dev"]["gchp"]["is_pre_13.1"],
+                gchp_is_pre_14.0=config["data"]["dev"]["gchp"]["is_pre_14.0"],
             )[0]
 
             # Pick output folder

--- a/docs/source/benchmark_plotting.rst
+++ b/docs/source/benchmark_plotting.rst
@@ -45,7 +45,8 @@ data:
       subdir: OutputDir
       bmk_start: "2019-07-01T00:00:00"
       bmk_end: "2019-08-01T00:00:00"
-      is_legacy: False # Whether GCHP files are legacy (pre-13.1) format
+      is_pre_13.1: False # Whether GCHP files are format before version 13.1
+      is_pre_14.0: True # Whether GCHP files are format before version 14.0
   dev:
     gcc:
       version: GCC_dev 
@@ -60,7 +61,8 @@ data:
       bmk_start: "2019-07-01T00:00:00" 
       bmk_end: "2019-08-01T00:00:00"
       is_legacy: False
-
+      is_pre_13.1: False # Whether GCHP files are format before version 13.1
+      is_pre_14.0: True # Whether GCHP files are format before version 14.0
 options:
   bmk_type: FullChemBenchmark
   gcpy_test: True # Specify if this is a gcpy test validation run


### PR DESCRIPTION
This PR goes with https://github.com/geoschem/geos-chem/pull/1259. That update changes the GCHP restart file format and stores GCHP restart files in a Restarts subdirectory. This update adds a toggle for GCHP versions before 14.0, assuming the GCHP run directory updates are included in 14.0. I also changed the "is_legacy" toggle to specifically be for versions before 13.1. That toggle should be included until after the 14.0 10-year benchmark that will compare against 13.0.