### PR TITLE
Add fix for GEOS-Chem Classic restart file path

### DIFF
--- a/benchmark/1mo_benchmark.yml
+++ b/benchmark/1mo_benchmark.yml
@@ -27,6 +27,7 @@ data:
       subdir: OutputDir
       bmk_start: "2019-07-01T00:00:00" 
       bmk_end: "2019-08-01T00:00:00"
+      is_pre_14.0: False
     gchp:
       version: GCHP_ref
       dir: GCHP_ref
@@ -42,6 +43,7 @@ data:
       subdir: OutputDir
       bmk_start: "2019-07-01T00:00:00" 
       bmk_end: "2019-08-01T00:00:00"
+      is_pre_14.0: False
     gchp:
       version: GCHP_dev
       dir: GCHP_dev
@@ -49,7 +51,7 @@ data:
       bmk_start: "2019-07-01T00:00:00" 
       bmk_end: "2019-08-01T00:00:00"
       is_pre_13.1: False
-      is_pre_14.0: True
+      is_pre_14.0: False
 
 options:
   bmk_type: FullChemBenchmark

--- a/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -133,17 +133,17 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
     gcc_vs_gcc_refrstdir = join(
         config["paths"]["main_dir"],
         config["data"]["ref"]["gcc"]["version"],
-        "restarts"
+        "Restarts"
     )
     gcc_vs_gcc_devrstdir = join(
         config["paths"]["main_dir"],
         config["data"]["dev"]["gcc"]["version"],
-        "restarts"
+        "Restarts"
     )
     gchp_vs_gcc_refrstdir = join(
         config["paths"]["main_dir"],
         config["data"]["dev"]["gcc"]["version"],
-        "restarts"
+        "Restarts"
     )
     gchp_vs_gcc_devrstdir = join(
         config["paths"]["main_dir"],

--- a/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/benchmark/modules/run_1yr_tt_benchmark.py
@@ -128,13 +128,13 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
 
     # Restart file directory paths
     gcc_vs_gcc_refrstdir = join(
-        config["paths"]["main_dir"], config["data"]["ref"]["gcc"]["dir"], "restarts"
+        config["paths"]["main_dir"], config["data"]["ref"]["gcc"]["dir"], "Restarts"
     )
     gcc_vs_gcc_devrstdir = join(
-        config["paths"]["main_dir"], config["data"]["dev"]["gcc"]["dir"], "restarts"
+        config["paths"]["main_dir"], config["data"]["dev"]["gcc"]["dir"], "Restarts"
     )
     gchp_vs_gcc_refrstdir = join(
-        config["paths"]["main_dir"], config["data"]["dev"]["gcc"]["dir"], "restarts"
+        config["paths"]["main_dir"], config["data"]["dev"]["gcc"]["dir"], "Restarts"
     )
     gchp_vs_gcc_devrstdir = join(
         config["paths"]["main_dir"], config["data"]["dev"]["gchp"]["dir"]

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -906,7 +906,8 @@ def run_benchmark_default(config):
                 gchp_end_dev_date,
                 is_gchp=True,
                 gchp_res=gchp_dev_res,
-                gchp_is_pre_14_0=config["data"]["dev"]["gchp"]["is_pre_14.0"]
+                gchp_is_pre_14_0=config["data"]["dev"]["gchp"]["is_pre_14.0"],
+                gcc_is_pre_14_0=config["data"]["dev"]["gcc"]["is_pre_14.0"]
             )
 
             # Create tables

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -1648,7 +1648,8 @@ def get_filepath(
         is_gchp=False,
         gchp_res="00",
         gchp_is_pre_13_1=False,
-        gchp_is_pre_14_0=False
+        gchp_is_pre_14_0=False,
+        gcc_is_pre_14_0=False
 ):
     """
     Routine to return file path for a given GEOS-Chem "Classic"
@@ -1677,6 +1678,10 @@ def get_filepath(
 
         gchp_is_pre_14_0: bool
             Set this switch to True to obtain GCHP file pathnames used in
+            versions before 14.0. Only needed for restart files.
+
+        gcc_is_pre_14_0: bool
+            Set this switch to True to obtain GCClassic file pathnames used in
             versions before 14.0. Only needed for restart files.
 
     Returns:
@@ -1710,7 +1715,10 @@ def get_filepath(
             extension = ".nc"
             separator = ""
         elif "Restart" in col:
-            file_tmpl = os.path.join(datadir, "Restarts/GEOSChem.Restart.")
+            if gcc_is_pre_14_0:
+                file_tmpl = os.path.join(datadir, "restarts/GEOSChem.Restart.")
+            else:
+                file_tmpl = os.path.join(datadir, "Restarts/GEOSChem.Restart.")
         else:
             file_tmpl = os.path.join(datadir, "GEOSChem.{}.".format(col))
     if isinstance(date_str, np.str_):
@@ -1736,7 +1744,8 @@ def get_filepaths(
         is_gchp=False,
         gchp_res="00",
         gchp_is_pre_13_1=False,
-        gchp_is_pre_14_0=False
+        gchp_is_pre_14_0=False,
+        gcc_is_pre_14_0=False
 ):
     """
     Routine to return filepaths for a given GEOS-Chem "Classic"
@@ -1765,6 +1774,10 @@ def get_filepaths(
 
         gchp_is_pre_14_0: bool
             Set this switch to True to obtain GCHP file pathnames used in
+            versions before 14.0. Only needed for diagnostic files.
+
+        gcc_is_pre_14_0: bool
+            Set this switch to True to obtain GCClassic file pathnames used in
             versions before 14.0. Only needed for diagnostic files.
 
     Returns:
@@ -1821,8 +1834,12 @@ def get_filepaths(
                 separator = ""
                 extension = ".nc"
             elif "Restart" in collection:
-                file_tmpl = os.path.join(datadir,
-                                         "Restarts/GEOSChem.Restart.")
+                if gcc_is_pre_14_0:
+                    file_tmpl = os.path.join(datadir,
+                                             "restarts/GEOSChem.Restart.")
+                else:
+                    file_tmpl = os.path.join(datadir,
+                                             "Restarts/GEOSChem.Restart.")
 
             else:
                 file_tmpl = os.path.join(datadir,

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -1709,6 +1709,8 @@ def get_filepath(
             file_tmpl = os.path.join(datadir, "HEMCO_diagnostics.")
             extension = ".nc"
             separator = ""
+        elif "Restart" in col:
+            file_tmpl = os.path.join(datadir, "Restarts/GEOSChem.Restart.")
         else:
             file_tmpl = os.path.join(datadir, "GEOSChem.{}.".format(col))
     if isinstance(date_str, np.str_):
@@ -1818,6 +1820,10 @@ def get_filepaths(
                                          "HEMCO_diagnostics.")
                 separator = ""
                 extension = ".nc"
+            elif "Restart" in collection:
+                file_tmpl = os.path.join(datadir,
+                                         "Restarts/GEOSChem.Restart.")
+
             else:
                 file_tmpl = os.path.join(datadir,
                                          "GEOSChem.{}.".format(collection))


### PR DESCRIPTION
GEOS-Chem Classic and GCHP restart files are now saved to a Restarts subdirectory.

This partially addresses issue https://github.com/geoschem/gcpy/issues/158, but as pointed out there it would be best to eventually specify the path in the configuration file.