### PR TITLE
Add capability to generate CH4 benchmark output

### DIFF
--- a/benchmark/1yr_ch4_benchmark.yml
+++ b/benchmark/1yr_ch4_benchmark.yml
@@ -1,0 +1,115 @@
+&---
+# =====================================================================
+# Benchmark configuration file (**EDIT AS NEEDED**)
+# customize in the following manner:
+# (1) Edit the path variables so that they point to folders w/ model data
+# (2) Edit the version strings for each benchmark simulation
+# (3) Edit the switches that turn on/off creating of plots and tables
+# (4) If necessary, edit labels for the dev and ref versions
+# Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
+# to gcc_dev (not gcc_ref!). This ensures consistency in version names
+# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# =====================================================================
+#
+# Configuration for 1yr CH4Benchmark
+#
+# paths:
+#   main_dir:    High-level directory containing ref & dev rundirs
+#   results_dir: Directory where plots/tables will be created
+#   weights_dir: Path to regridding weights
+#   spcdb_dir:   Folder in which the species_database.yml file is
+#                located.  If set to "default", then will look for
+#                species_database.yml in one of the Dev rundirs.
+#
+paths:
+  main_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/geos-chem/validation/gcpy_test_data/1yr_fullchem
+  results_dir: /path/to/BenchmarkResults
+  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
+  spcdb_dir: default
+#
+# data: Contains configurations for ref and dev runs
+#   version:         Version string (must not contain spaces)
+#   dir:             Path to run directory
+#   outputs_subdir:  Subdirectory w/ GEOS-Chem diagnostic files
+#   restarts_subdir: Subdirectory w/ GEOS-Chem restarts
+#   bmk_start:       Simulation start date (YYYY-MM-DDThh:mm:ss)
+#   bmk_end:         Simulation end date (YYYY-MM-DDThh:mm:ss)
+#   resolution:      GCHP resolution string
+#
+data:
+  ref:
+    gcc:
+      version: GCC_ref
+      dir: GCC_ref
+      outputs_subdir: OutputDir
+      restarts_subdir: Restarts
+      bmk_start: "2019-01-01T00:00:00"
+      bmk_end: "2020-01-01T00:00:00"
+    gchp:
+      version: GCHP_ref
+      dir: GCHP_ref
+      outputs_subdir: OutputDir
+      restarts_subdir: Restarts
+      bmk_start: "2019-01-01T00:00:00"
+      bmk_end: "2020-01-01T00:00:00"
+      is_pre_13.1: False               # for gcpy_test_data, edit if needed
+      is_pre_14.0: False               # for gcpy_test_data, edit if needed
+      resolution: c24                  # for gcpy_test_data, edit if needed
+  dev:
+    gcc:
+      version: GCC_dev
+      dir: GCC_dev
+      outputs_subdir: OutputDir
+      restarts_subdir: Restarts
+      bmk_start: "2019-01-01T00:00:00"
+      bmk_end: "2020-01-01T00:00:00"
+    gchp:
+      version: GCHP_dev
+      dir: GCHP_dev
+      outputs_subdir: OutputDir
+      restarts_subdir: Restarts
+      bmk_start: "2019-01-01T00:00:00"
+      bmk_end: "2020-01-01T00:00:00"
+      is_pre_13.1: False              # for gcpy_test_data, edit if needed
+      is_pre_14.0: False              # for gcpy_test_data, edit if needed
+      resolution: c24                 # for gcpy_test_data, edit if needed   
+#
+# options: Specify the types of comparisons to perform
+# 
+options:
+  bmk_type: CH4Benchmark
+  gcpy_test: False # Specify if this is a gcpy test validation run
+  comparisons:
+    gcc_vs_gcc: 
+      run: True # True to run this comparison
+      dir: GCC_version_comparison
+      tables_subdir: Tables
+    gchp_vs_gcc: 
+      run: False
+      dir: GCHP_GCC_comparison 
+      tables_subdir: Tables
+    gchp_vs_gchp: 
+      run: False
+      dir: GCHP_version_comparison
+      tables_subdir: Tables
+    gchp_vs_gcc_diff_of_diffs:
+      run: False
+      dir: GCHP_GCC_diff_of_diffs
+#
+# outputs: Types of output to generate (plots/tables)
+#
+  outputs:
+    plot_conc: True
+    plot_emis: True
+    emis_table: True
+    plot_jvalues: False
+    plot_aod: False
+    mass_table: True
+    ops_budget_table: False
+    aer_budget_table: False
+    Ox_budget_table: False
+    ste_table: False
+    OH_metrics: True
+    plot_options:
+      by_spc_cat: True
+      by_hco_cat: True

--- a/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -477,6 +477,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "plot_options"]["by_spc_cat"],
                 plot_by_hco_cat=config["options"]["outputs"][
                     "plot_options"]["by_hco_cat"],
+                benchmark_type=bmk_type,
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
             )
@@ -501,6 +502,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "plot_options"]["by_spc_cat"],
                     plot_by_hco_cat=config["options"]["outputs"][
                         "plot_options"]["by_hco_cat"],
+                    benchmark_type=bmk_type,
                     overwrite=True,
                     spcdb_dir=spcdb_dir,
                 )

--- a/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -532,6 +532,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 dev,
                 gcc_vs_gcc_devstr,
                 dst=gcc_vs_gcc_resultsdir,
+                benchmark_type=bmk_type,
                 ref_interval=sec_per_month_ref,
                 dev_interval=sec_per_month_dev,
                 overwrite=True,

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -77,10 +77,12 @@ def choose_benchmark_type(config):
     if not (
         config["options"]["bmk_type"] == "FullChemBenchmark"
         or config["options"]["bmk_type"] == "TransportTracersBenchmark"
+        or config["options"]["bmk_type"] == "CH4Benchmark"
     ):
         print(
             f"Error: invalid benchmark type {config['options']['bmk_type']}. "
-            + "Please enter FullChemBenchmark or TransportTracersBenchmark."
+            + "Please enter FullChemBenchmark, TransportTracersBenchmark, or "
+            + "CH4Benchmark."
         )
         sys.exit()
 
@@ -88,7 +90,10 @@ def choose_benchmark_type(config):
     end = np.datetime64(config["data"]["ref"]["gcc"]["bmk_end"])
     # determine benchmark type and run relevant script
     if is_full_year(start, end):
-        if config["options"]["bmk_type"] == "FullChemBenchmark":
+        if (
+            config["options"]["bmk_type"] == "FullChemBenchmark"
+            or config["options"]["bmk_type"] == "CH4Benchmark"
+        ):
             run_1yr_benchmark(
                 config,
                 str(start.astype(datetime).year),

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -527,7 +527,7 @@ def run_benchmark_default(config):
         # GCC vs. GCC tables of emission and inventory totals
         # ==================================================================
         if config["options"]["outputs"]["emis_table"]:
-            print("\n%%% Creating GCC vs. GCC emissions/inventory tables %%%")
+            print("\n%%% Creating GCC vs. GCC emissions & inventory tables %%%")
 
             # Filepaths
             ref = get_filepath(gcc_vs_gcc_refdir, "Emissions", gcc_ref_date)

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -1222,6 +1222,7 @@ def make_benchmark_emis_plots(
         subdst=None,
         plot_by_spc_cat=False,
         plot_by_hco_cat=False,
+        benchmark_type="FullChemBenchmark",
         cmpres=None,
         overwrite=False,
         verbose=False,
@@ -1274,6 +1275,10 @@ def make_benchmark_emis_plots(
             according to HEMCO emissions categories (e.g. Anthro,
             Aircraft, Bioburn, etc.)
             Default value: False
+        benchmark_type: str
+            A string denoting the type of benchmark output to plot,
+            either FullChemBenchmark or TransportTracersBenchmark.
+            Default value: "FullChemBenchmark"
         cmpres: string
             Grid resolution at which to compare ref and dev data, e.g. '1x1.25'
         overwrite: bool
@@ -1529,7 +1534,7 @@ def make_benchmark_emis_plots(
     # ==================================================================
     if plot_by_spc_cat:
 
-        catdict = util.get_species_categories()
+        catdict = util.get_species_categories(benchmark_type)
         # in case any emissions are skipped (for use in nested pdf bookmarks)
         warninglist = ([])
         # for checking if emissions species not defined in benchmark category

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -30,7 +30,6 @@ np.seterr(divide="ignore", invalid="ignore")
 
 # YAML files
 aod_spc = "aod_species.yml"
-spc_categories = "benchmark_categories.yml"
 emission_spc = "emission_species.yml"
 emission_inv = "emission_inventories.yml"
 
@@ -616,8 +615,8 @@ def make_benchmark_conc_plots(
             Name of collection to use for plotting.
             Default value: "SpeciesConc"
         benchmark_type: str
-            A string denoting the type of benchmark output to plot,
-            either FullChemBenchmark or TransportTracersBenchmark.
+            A string denoting the type of benchmark output to plot, options are
+            FullChemBenchmark, TransportTracersBenchmark, or CH4Benchmark.
             Default value: "FullChemBenchmark"
         cmpres: string
             Grid resolution at which to compare ref and dev data, e.g. '1x1.25'
@@ -897,7 +896,7 @@ def make_benchmark_conc_plots(
     # aerosol categories: Aerosols and Secondary Organic Aerosols.
     # ==================================================================
 
-    # FullChemBenchmark has lumped species (TransportTracers does not)
+    # FullChemBenchmark has lumped species (TransportTracers, CH4 do not)
     if "FullChem" in benchmark_type:
         print("\nComputing lumped species for full chemistry benchmark")
         print("-->Adding lumped species to ref dataset")
@@ -1276,8 +1275,8 @@ def make_benchmark_emis_plots(
             Aircraft, Bioburn, etc.)
             Default value: False
         benchmark_type: str
-            A string denoting the type of benchmark output to plot,
-            either FullChemBenchmark or TransportTracersBenchmark.
+            A string denoting the type of benchmark output to plot, options are
+            FullChemBenchmark, TransportTracersBenchmark, or CH4Benchmark.
             Default value: "FullChemBenchmark"
         cmpres: string
             Grid resolution at which to compare ref and dev data, e.g. '1x1.25'
@@ -1635,6 +1634,7 @@ def make_benchmark_emis_tables(
         devlist,
         devstr,
         dst="./benchmark",
+        benchmark_type="FullChemBenchmark",
         refmet=None,
         devmet=None,
         overwrite=False,
@@ -1665,6 +1665,10 @@ def make_benchmark_emis_tables(
             A string denoting the destination folder where the file
             containing emissions totals will be written.
             Default value: ./benchmark
+        benchmark_type: str
+            A string denoting the type of benchmark output to plot, options are
+            FullChemBenchmark, TransportTracersBenchmark or CH4Benchmark.
+            Default value: "FullChemBenchmark"
         refmet: str
             Path name for ref meteorology
             Default value: None
@@ -1752,14 +1756,16 @@ def make_benchmark_emis_tables(
     # ==================================================================
 
     # Emissions species dictionary
-    species = yaml.load(
+    spc_dict = yaml.load(
         open(os.path.join(os.path.dirname(__file__), emission_spc)),
         Loader=yaml.FullLoader
     )
-    inventories = yaml.load(
+    species=spc_dict[benchmark_type]
+    inv_dict = yaml.load(
         open(os.path.join(os.path.dirname(__file__), emission_inv)),
         Loader=yaml.FullLoader
     )
+    inventories=inv_dict[benchmark_type]
 
     # Destination files
     file_emis_totals = os.path.join(emisdir, "Emission_totals.txt")
@@ -3063,8 +3069,8 @@ def make_benchmark_wetdep_plots(
             for writing plots
             Default value: None
         benchmark_type: str
-            A string denoting the type of benchmark output to plot,
-            either FullChemBenchmark or TransportTracersBenchmark.
+            A string denoting the type of benchmark output to plot, options are
+            FullChemBenchmark, TransportTracersBenchmark, or CH4Benchmark.
             Default value: "FullChemBenchmark"
         overwrite: bool
             Set this flag to True to overwrite files in the
@@ -3620,7 +3626,8 @@ def make_benchmark_operations_budget(
 
     Keyword Args (optional):
         benchmark_type: str
-            "TransportTracersBenchmark" or "FullChemBenchmark".
+            A string denoting the type of benchmark output to plot, options are
+            FullChemBenchmark, TransportTracersBenchmark, or CH4Benchmark.
             Default value: None
         label: str
             Contains the date or date range for each dataframe title.

--- a/gcpy/benchmark_categories.yml
+++ b/gcpy/benchmark_categories.yml
@@ -252,3 +252,7 @@ TransportTracersBenchmark:
       - Be7Strat
       - Be10
       - Be10Strat
+CH4Benchmark:
+  CH4:
+    CH4:
+      - CH4

--- a/gcpy/emission_inventories.yml
+++ b/gcpy/emission_inventories.yml
@@ -1,26 +1,31 @@
-AEIC: Tg
-AFCID: Tg
-APEI: Tg
-C2H62010: Tg
-CEDS: Tg
-CEDSship: Tg
-DEAD: Tg
-DICEAfrica: Tg
-GEIAnatural: Tg
-GFED: Tg
-IODINE: Tg
-LIANG: Tg
-LIGHTNOX: Tg
-MEGAN: Tg
-MIX: Tg
-NEI2011: Tg
-ORDONEZ: Tg
-PARANOX: Tg
-PLANTDECAY: Tg
-SEABIRDS: Tg
-SeaFlux: Tg
-SeaSalt: Tg
-SOILNOX: Tg
-VOLCANOdegas: Tg
-VOLCANOerupt: Tg
-XIAO: Tg
+FullChemBenchmark:
+  AEIC: Tg
+  AFCID: Tg
+  APEI: Tg
+  C2H62010: Tg
+  CEDS: Tg
+  CEDSship: Tg
+  DEAD: Tg
+  DICEAfrica: Tg
+  GEIAnatural: Tg
+  GFED: Tg
+  IODINE: Tg
+  LIANG: Tg
+  LIGHTNOX: Tg
+  MEGAN: Tg
+  MIX: Tg
+  NEI2011: Tg
+  ORDONEZ: Tg
+  PARANOX: Tg
+  PLANTDECAY: Tg
+  SEABIRDS: Tg
+  SeaFlux: Tg
+  SeaSalt: Tg
+  SOILNOX: Tg
+  VOLCANOdegas: Tg
+  VOLCANOerupt: Tg
+  XIAO: Tg
+CH4Benchmark:
+  GEPA: Tg
+  Scarpelli_Canada: Tg
+  Scarpelli_Mexico: Tg

--- a/gcpy/emission_species.yml
+++ b/gcpy/emission_species.yml
@@ -1,50 +1,52 @@
-ACET: Tg
-ALD2: Tg
-ALK4: Tg
-BCPI: Tg
-BCPO: Tg
-BENZ: Tg
-C2H6: Tg
-C3H8: Tg
-CH2Br2: Tg
-CH2O: Tg
-CH4: Tg
-CHBr3: Tg
-CO: Tg
-DMS: Tg
-DST1: Tg
-DST2: Tg
-DST3: Tg
-DST4: Tg
-EOH: Tg
-ETNO3: Tg
-GLYC: Tg
-GLYX: Tg
-HAC: Tg
-HCOOH: Tg
-HNO2: Tg
-HNO3: Tg
-ISOP: Tg
-LIMO: Tg
-MACR: Tg
-MEK: Tg
-MENO3: Tg
-MGLY: Tg
-MTPA: Tg
-MTPO: Tg
-NH3: Tg
-'NO': Tg
-NO2: Tg
-OCPI: Tg
-OCPO: Tg
-PRPE: Tg
-RCHO: Tg
-SALA: Tg
-SALC: Tg
-SO2: Tg
-SO4: Tg
-SOAP: Tg
-SOAS: Tg
-TOLU: Tg
-XYLE: Tg
-pFe: Tg
+FullChemBenchmark:
+  ACET: Tg
+  ALD2: Tg
+  ALK4: Tg
+  BCPI: Tg
+  BCPO: Tg
+  BENZ: Tg
+  C2H6: Tg
+  C3H8: Tg
+  CH2Br2: Tg
+  CH2O: Tg
+  CHBr3: Tg
+  CO: Tg
+  DMS: Tg
+  DST1: Tg
+  DST2: Tg
+  DST3: Tg
+  DST4: Tg
+  EOH: Tg
+  ETNO3: Tg
+  GLYC: Tg
+  GLYX: Tg
+  HAC: Tg
+  HCOOH: Tg
+  HNO2: Tg
+  HNO3: Tg
+  ISOP: Tg
+  LIMO: Tg
+  MACR: Tg
+  MEK: Tg
+  MENO3: Tg
+  MGLY: Tg
+  MTPA: Tg
+  MTPO: Tg
+  NH3: Tg
+  'NO': Tg
+  NO2: Tg
+  OCPI: Tg
+  OCPO: Tg
+  PRPE: Tg
+  RCHO: Tg
+  SALA: Tg
+  SALC: Tg
+  SO2: Tg
+  SO4: Tg
+  SOAP: Tg
+  SOAS: Tg
+  TOLU: Tg
+  XYLE: Tg
+  pFe: Tg
+CH4Benchmark:
+  CH4: Tg

--- a/gcpy/emission_species.yml
+++ b/gcpy/emission_species.yml
@@ -8,6 +8,7 @@ C2H6: Tg
 C3H8: Tg
 CH2Br2: Tg
 CH2O: Tg
+CH4: Tg
 CHBr3: Tg
 CO: Tg
 DMS: Tg


### PR DESCRIPTION
This PR adds the benchmark type "CH4Benchmark" for validating GEOS-Chem CH4 simulations. This option utilizes the existing benchmark code and a reduced set of options from the FullChemBenchmark type (concentration plots, emission plots, emission tables, mass tables, OH metrics).