### PR TITLE
Update SpeciesConc variable name to SpeciesConcVV for consistency with GEOS-Chem 14.1.0 updates

### DIFF
--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -721,7 +721,7 @@ def make_benchmark_conc_plots(
             refds = refds.rename({v: 'SpeciesConcVV_' + spc})
     for v in devds.data_vars.keys():
         if v.startswith('SpeciesConc_'):
-            spc = v.replace('Species_Conc', '')
+            spc = v.replace('SpeciesConc_', '')
             devds = devds.rename({v: 'SpeciesConcVV_' + spc})
 
     # -----------------------------------------------------------------
@@ -3424,7 +3424,7 @@ def make_benchmark_aerosol_tables(
     # naming introduced in GEOS-Chem 14.1.0
     for v in ds_spc.data_vars.keys():
         if v.startswith('SpeciesConc_'):
-            spc = v.replace('Species_Conc', '')
+            spc = v.replace('SpeciesConc_', '')
             ds_spc = ds_spc.rename({v: 'SpeciesConcVV_' + spc})
 
     # Get troposphere mask

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -344,8 +344,8 @@ def add_bookmarks_to_pdf(
         remove_prefix: str
             Specifies a prefix to remove from each entry in varlist
             when creating bookmarks.  For example, if varlist has
-            a variable name "SpeciesConc_NO", and you specify
-            remove_prefix="SpeciesConc_", then the bookmark for
+            a variable name "SpeciesConcVV_NO", and you specify
+            remove_prefix="SpeciesConcVV_", then the bookmark for
             that variable will be just "NO", etc.
          verbose: bool
             Set this flag to True to print extra informational output.
@@ -1168,7 +1168,7 @@ def add_lumped_species_to_dataset(
         lspc_yaml="",
         verbose=False,
         overwrite=False,
-        prefix="SpeciesConc_",
+        prefix="SpeciesConcVV_",
 ):
     """
     Function to calculate lumped species concentrations and add
@@ -1204,7 +1204,7 @@ def add_lumped_species_to_dataset(
             also used to extract an existing dataarray in the dataset with
             the correct size and dimensions to use during initialization of
             new lumped species dataarrays.
-            Default value: "SpeciesConc_"
+            Default value: "SpeciesConcVV_"
 
     Returns:
         ds: xarray Dataset


### PR DESCRIPTION
In GEOS-Chem 14.1.0, the SpeciesConc collection may now be saved out with variable names SpeciesConcVV or SpeciesConcMND. To allow for comparison with output from earlier versions, we now rename SpeciesConc to SpeciesConcVV within benchmark.py.

See corresponding GEOS-Chem PR https://github.com/geoschem/geos-chem/pull/1572