### PR TITLE
Fix bug in GCHP transport tracer budget table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.3.2] -- 2022-10-25
 
-### Changed
-- Bug fix: Fixed malformed version declaration for cartopy (use `==`
+### Fixes
+- Fixed malformed version declaration for cartopy (use `==`
   instead of `=`) in setup.py.  This was preventing upload to
   conda-forge.
-     
+- Vertically flip GCHP emissions when computing transport tracers budget
+
 ## [1.3.1] -- 2022-10-25
 
 ### Changed

--- a/gcpy/budget_tt.py
+++ b/gcpy/budget_tt.py
@@ -559,17 +559,17 @@ def annual_average_sources(globvars):
         raise ValueException(msg)
 
     # Convert Be7 and Be10 sources from kg/m2/s to g/day
-    # NOTE: This is a kludgey way to do it but it works and
-    # preserves the shape of the data as (time,lev,lat,lon).
+    # If GCHP data, must vertically flip the emissions diagnostic
     for t in range(globvars.N_MONTHS):
         for k in range(n_levs):
             if globvars.is_gchp:
+                kf = n_levs - k - 1
                 q["Be7_f"][t, k, :, :, :] = \
-                    globvars.ds_hco["EmisBe7_Cosmic"].isel(time=t, lev=k) * \
+                    globvars.ds_hco["EmisBe7_Cosmic"].isel(time=t, lev=kf) * \
                     globvars.ds_met[area_var].isel(time=t) * \
                     globvars.kg_s_to_g_d["Be7"]
                 q["Be10_f"][t, k, :, :, :] = \
-                    globvars.ds_hco["EmisBe10_Cosmic"].isel(time=t, lev=k) * \
+                    globvars.ds_hco["EmisBe10_Cosmic"].isel(time=t, lev=kf) * \
                     globvars.ds_met[area_var].isel(time=t) * \
                     globvars.kg_s_to_g_d["Be10"]
             else:


### PR DESCRIPTION
This pull request fixes a bug reported by @1Dandan in which GCHP transport tracers budget source is incorrect because the emissions diagnostic is not flipped. All emission diagnostics output by GCHP in versions 14 and prior have level 1 correspond to top-of-atmosphere. 

closes https://github.com/geoschem/gcpy/issues/185