### PR TITLE
Update benchmark table output to better show which diagnostics have Ref = Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+- Benchmark summary table output (intended for 1hr & 1mo benchmarks)
+- Species/emissions/inventories that differ between Dev & Ref versions are now printed at the top of the benchmark emissions, inventory, and global mass tables.  if there are too many species with diffs, an alternate message is printed.
+- New functions in `benchmark.py` and `util.py` to facilitate printing of the species/emissions/inventories that differ between Dev & Ref versions.
+
 ## [1.3.2] -- 2022-10-25
 
 ### Fixes

--- a/benchmark/1mo_benchmark.yml
+++ b/benchmark/1mo_benchmark.yml
@@ -108,6 +108,7 @@ options:
     ops_budget_table: False
     OH_metrics: True
     ste_table: True # GCC only
+    summary_table: True
     plot_options: # Plot concentrations and emissions by category?
       by_spc_cat: True
       by_hco_cat: True

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -642,29 +642,6 @@ def run_benchmark_default(config):
         if config["options"]["outputs"]["OH_metrics"]:
             print("\n%%% Creating GCC vs. GCC OH metrics table %%%")
 
-            # Use this for benchmarks prior to GEOS-Chem 13.0.0
-            #        # Diagnostic collection files to read
-            #        col  = "ConcAfterChem"
-            #        ref = get_filepath(gcc_vs_gcc_refdir, col, gcc_ref_date)
-            #        dev = get_filepath(gcc_vs_gcc_devdir, col, gcc_dev_date)
-            #
-            #        # Meteorology data needed for calculations
-            #        col = "StateMet"
-            #        refmet = get_filepath(gcc_vs_gcc_refdir, col, gcc_ref_date)
-            #        devmet = get_filepath(gcc_vs_gcc_devdir, col, gcc_dev_date)
-            #
-            #        # Print OH metrics
-            #        bmk.make_benchmark_oh_metrics(
-            #            ref,
-            #            refmet,
-            #            config["data"]["ref"]["gcc"]["version"],
-            #            dev,
-            #            devmet,
-            #            config["data"]["dev"]["gcc"]["version"],
-            #            dst=gcc_vs_gcc_tablesdir,
-            #            overwrite=True
-            #        )
-
             # Filepaths
             ref = get_filepath(gcc_vs_gcc_refdir, "Metrics", gcc_ref_date)
             dev = get_filepath(gcc_vs_gcc_devdir, "Metrics", gcc_dev_date)
@@ -702,6 +679,48 @@ def run_benchmark_default(config):
                     overwrite=True,
                     month=gcc_dev_date.astype(datetime).month,
                 )
+
+        # ==================================================================
+        # GCC vs. GCC summary table
+        # ==================================================================
+        if config["options"]["outputs"]["summary_table"]:
+            print("\n%%% Creating GCC vs. GCC summary table %%%")
+
+            # Diagnostic collections to check
+            collections = [
+                'AerosolMass',
+                'Aerosols',
+                'Emissions',
+                'JValues',
+                'Metrics',
+                'SpeciesConc',
+                'StateMet',
+            ]
+
+            # Print summary of which collections are identical
+            # between Ref & Dev, and which are not identical.
+            bmk.create_benchmark_summary_table(
+                gcc_vs_gcc_refdir,
+                config["data"]["ref"]["gcc"]["version"],
+                gcc_ref_date,
+                gcc_vs_gcc_devdir,
+                config["data"]["dev"]["gcc"]["version"],
+                gcc_dev_date,
+                collections = [
+                    'AerosolMass',
+                    'Aerosols',
+                    'Emissions',
+                    'JValues',
+                    'Metrics',
+                    'SpeciesConc',
+                    'StateMet'
+                ],
+                dst=gcc_vs_gcc_tablesdir,
+                outfilename="Summary.txt",
+                overwrite=True,
+                verbose=False,
+            )
+
 
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create GCHP vs GCC benchmark plots and tables
@@ -1013,6 +1032,38 @@ def run_benchmark_default(config):
         if config["options"]["outputs"]["ste_table"]:
             title = "\n%%% Skipping GCHP vs. GCC Strat-Trop Exchange table %%%"
             print(title)
+
+
+        # ==================================================================
+        # GCHP vs. GCC summary table
+        # ==================================================================
+        if config["options"]["outputs"]["summary_table"]:
+            print("\n%%% Creating GCHP vs. GCC summary table %%%")
+
+            # Print summary of which collections are identical
+            # between Ref & Dev, and which are not identical.
+            bmk.create_benchmark_summary_table(
+                gchp_vs_gcc_refdir,
+                config["data"]["dev"]["gcc"]["version"],
+                gcc_dev_date,
+                gchp_vs_gcc_devdir,
+                config["data"]["dev"]["gchp"]["version"],
+                gchp_dev_date,
+                collections=[
+                    'AerosolMass',
+                    'Aerosols',
+                    'Emissions',
+                    'JValues',
+                    'Metrics',
+                    'SpeciesConc',
+                    'StateMet',
+                ],
+                dst=gchp_vs_gcc_tablesdir,
+                outfilename="Summary.txt",
+                overwrite=True,
+                verbose=False,
+                dev_gchp=True
+            )
 
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create GCHP vs GCHP benchmark plots and tables
@@ -1376,6 +1427,38 @@ def run_benchmark_default(config):
         if config["options"]["outputs"]["ste_table"]:
             print("\n%%% Skipping GCHP vs. GCHP Strat-Trop Exchange table %%%")
 
+        # ==================================================================
+        # GCHP vs. GCHP summary table
+        # ==================================================================
+        if config["options"]["outputs"]["summary_table"]:
+            print("\n%%% Creating GCHP vs. GCHP summary table %%%")
+
+            # Print summary of which collections are identical
+            # between Ref & Dev, and which are not identical.
+            bmk.create_benchmark_summary_table(
+                gchp_vs_gchp_refdir,
+                config["data"]["ref"]["gchp"]["version"],
+                gchp_ref_date,
+                gchp_vs_gchp_devdir,
+                config["data"]["dev"]["gchp"]["version"],
+                gchp_dev_date,
+                collections=[
+                    'AerosolMass',
+                    'Aerosols',
+                    'Emissions',
+                    'JValues',
+                    'Metrics',
+                    'SpeciesConc', 
+                    'StateMet',
+                ],
+                dst=gchp_vs_gchp_tablesdir,
+                outfilename="Summary.txt",
+                overwrite=True,
+                verbose=False,
+                ref_gchp=True,
+                dev_gchp=True,
+            )
+
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create GCHP vs GCC difference of differences benchmark plots
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1423,7 +1506,7 @@ def run_benchmark_default(config):
     # ==================================================================
     # Print a message indicating that the benchmarks finished
     # ==================================================================
-    print("\n %%%% All requested benchmark plots/tables created! %%%%")
+    print("\n%%%% All requested benchmark plots/tables created! %%%%")
 
 
 def main():

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -184,11 +184,7 @@ def create_total_emissions_table(
 
     # Write a placeholder to the file that denotes where
     # the list of species with differences will be written
-    placeholder = "@%% insert diff_list here %%@"
-    if "Inv" in template:
-        print(f"Inventories that differ btw {refstr} and {devstr}:", file=f)
-    else:
-        print(f"Species that differ btw {refstr} and {devstr}:", file=f)
+    placeholder = "@%% insert diff status here %%@"
     print(f"{placeholder}\n\n", file=f)
 
     # Define a list for differences
@@ -355,7 +351,10 @@ def create_total_emissions_table(
     util.insert_text_into_file(
         filename=outfilename,
         search_text=placeholder,
-        replace_text=diff_list_to_text(diff_list),
+        replace_text=diff_list_to_text(
+            refstr,
+            devstr,
+            diff_list),
         width=90
     )
 
@@ -464,19 +463,16 @@ def create_global_mass_table(
     if trop_only:
         title1 = f"### Global mass (Gg) {label} (Trop only)"
     title2 = f"### Ref = {refstr}; Dev = {devstr}"
-    title3 = f"### Species that differ btw {refstr} and {devstr}:"
 
     # Write a placeholder to the file that denotes where
     # the list of species with differences will be written
-    placeholder = "@%% insert diff_list here %%@"
-    title4 = f"{placeholder}"
+    placeholder = "@%% insert diff status here %%@"
 
     # Print header to file
     print("#" * 89, file=f)
     print(f"{title1 : <86}{'###'}", file=f)
     print(f"{title2 : <86}{'###'}", file=f)
     print(f"{'###'  : <86}{'###'}", file=f)
-    print(f"{title3 : <86}{'###'}", file=f)
     print(f"{placeholder}", file=f)
     print("#" * 89, file=f)
 
@@ -577,6 +573,8 @@ def create_global_mass_table(
         filename=outfilename,
         search_text=placeholder,
         replace_text=diff_list_to_text(
+            refstr,
+            devstr,
             diff_list,
             fancy_format=True
         ),
@@ -4604,6 +4602,8 @@ def create_benchmark_summary_table(
 
 
 def diff_list_to_text(
+        refstr,
+        devstr,
         diff_list,
         fancy_format=False
 ):
@@ -4629,13 +4629,21 @@ def diff_list_to_text(
     # Strip out duplicates from diff_list
     # Prepare a message about species differences (or alternate msg)
     diff_list = util.unique_values(diff_list, drop=[None])
-    diff_text = util.wrap_text(diff_list, width=85)
-    if len(diff_text) > 85:
-        diff_text = "... Too many diffs to print (see below for details)"
 
+    # Print the text
+    n_diff = len(diff_list)
+    if n_diff > 0:
+        diff_text = f"{devstr} and {refstr} show {n_diff} differences"
+    else:
+        diff_text = f"{devstr} and {refstr} are identical"
+    diff_text = util.wrap_text(
+        diff_text,
+        width=83
+    )
+        
     if fancy_format:
         diff_text = f"### {diff_text : <82}{'###'}"
-
+        
     return diff_text.strip()
 
 

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -4513,8 +4513,7 @@ def create_benchmark_summary_table(
 
     # Variables to skip
     skip_vars = gcon.skip_these_vars
-    skip_vars.append("corner_lats")
-    skip_vars.append("corner_lons")
+    skip_vars.append("AREA")
 
     # Pick the proper function to read the data
     reader = util.dataset_reader(
@@ -4569,9 +4568,14 @@ def create_benchmark_summary_table(
         diff_list = []
 
         # Keep track of which variables are different
-        # Loop over the common variables
+        # NOTE: Use 32-point float for comparisons since this is
+        # the precision used for History diagnostics.
         for v in vardict["commonvarsData"]:
-            if not util.array_equals(refdata[v], devdata[v]):
+            if not util.array_equals(
+                    refdata[v],
+                    devdata[v],
+                    dtype=np.float32
+            ):
                 diff_list.append(v)
 
         # Drop duplicate values from diff_list

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -176,10 +176,11 @@ def create_total_emissions_table(
     # =================================================================
     # Open the file for output
     # =================================================================
+    # Create file
     try:
         f = open(outfilename, "w")
-    except FileNotFoundError:
-        msg = "Could not open {} for writing!".format(outfilename)
+    except (IOError, OSError, FileNotFoundError) as e:
+        msg = f"Could not open {outfilename} for writing!"
         raise FileNotFoundError(msg)
 
     # =================================================================
@@ -220,29 +221,35 @@ def create_total_emissions_table(
 
         # Title strings
         if "Inv" in template:
-            print("Computing inventory totals for {}".format(species_name))
-            title1 = "### Emissions totals for inventory {} [Tg]".format(
-                species_name)
+            print(f"Computing inventory totals for {species_name}")
+            title0 = f"for inventory {species_name}"
+            title1 = f"### Emissions totals {title0} [Tg]"
         else:
-            print("Computing emissions totals for {}".format(species_name))
-            title1 = "### Emissions totals for species {} [Tg]".format(species_name)
+            print(f"Computing emissions totals for {species_name}")
+            title0 = f"for species {species_name}"
+            title1 = f"### Emissions totals {title0} [Tg]"
 
-        title2 = "### Ref = {}; Dev = {}".format(refstr, devstr)
+        title2 = f"### Ref = {refstr}; Dev = {devstr}"
+
+        # Determine if the all DataArrays for a given species or
+        # have identical data, and define a display string.
+        diagnames = [v for v in varnames if species_name in v]
+        diff_ct = 0
+        for v in diagnames:
+            if np.array_equal(refdata[v].values, devdata[v].values):
+                diff_ct += 1
+        diff_str = f"### Dev differs from Ref {title0}"
+        if diff_ct == len(diagnames):
+            diff_str = f"### Dev is identical to Ref {title0}"
 
         # Print header to file
-        print("#" * 83, file=f)
-        print("{}{}".format(title1.ljust(80), "###"), file=f)
-        print("{}{}".format(title2.ljust(80), "###"), file=f)
-        print("#" * 83, file=f)
-        print(
-            "{}{}{}{}{}".format(
-                " ".ljust(19),
-                "Ref".rjust(20),
-                "Dev".rjust(20),
-                "Dev - Ref".rjust(14),
-                "% diff".rjust(10),
-            ),
-            file=f)
+        print("#" * 91, file=f)
+        print(f"{title1 : <88}{'###'}", file=f)
+        print(f"{title2 : <88}{'###'}", file=f)
+        print(f"{'###' : <88}{'###'}", file=f)
+        print(f"{diff_str : <88}{'###'}", file=f)
+        print("#" * 91, file=f)
+        print(f"{'' : <19}{'Ref' : >20}{'Dev' : >20}{'Dev - Ref' : >14}{'% diff' : >10} {'no-diff'}", file=f)
 
         # =============================================================
         # Loop over all emissions variables corresponding to this
@@ -449,12 +456,12 @@ def create_global_mass_table(
     title2 = f"### Ref = {refstr}; Dev = {devstr}"
 
     # Print header to file
-    print("#" * 83, file=f)
-    print(f"{title1 : <80}{'###'}", file=f)
-    print(f"{title2 : <80}{'###'}", file=f)
-    print(f"{'###' : <80}{'###'}", file=f)
-    print(f"{diff_str : <80}{'###'}", file=f)
-    print("#" * 83, file=f)
+    print("#" * 91, file=f)
+    print(f"{title1 : <88}{'###'}", file=f)
+    print(f"{title2 : <88}{'###'}", file=f)
+    print(f"{'###' : <88}{'###'}", file=f)
+    print(f"{diff_str : <88}{'###'}", file=f)
+    print("#" * 91, file=f)
     print(f"{'' : <19}{'Ref' : >20}{'Dev' : >20}{'Dev - Ref' : >14}{'% diff' : >10} {'no-diff'}", file=f)
 
     # ==================================================================

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -433,32 +433,29 @@ def create_global_mass_table(
     # Create file
     try:
         f = open(outfilename, "w")
-    except FileNotFoundError:
-        msg = "Could not open {} for writing!".format(outfilename)
+    except (IOError, OSError, FileNotFoundError) as e:
+        msg = f"Could not open {outfilename} for writing!"
         raise FileNotFoundError(msg)
 
+    # Determine if the two data sets are identical
+    diff_str="### Dev differs from Ref"
+    if xr.Dataset.equals(refdata, devdata):
+        diff_str="### Dev is identical to Ref"
+
     # Title strings
+    title1 = f"### Global mass (Gg) {label} (Trop + Strat)"
     if trop_only:
-        title1 = "### Global mass (Gg) {} (Trop only)".format(label)
-    else:
-        title1 = "### Global mass (Gg) {} (Trop + Strat)".format(label)
-    title2 = "### Ref = {}; Dev = {}".format(refstr, devstr)
+        title1 = f"### Global mass (Gg) {label} (Trop only)"
+    title2 = f"### Ref = {refstr}; Dev = {devstr}"
 
     # Print header to file
     print("#" * 83, file=f)
-    print("{}{}".format(title1.ljust(80), "###"), file=f)
-    print("{}{}".format(title2.ljust(80), "###"), file=f)
+    print(f"{title1 : <80}{'###'}", file=f)
+    print(f"{title2 : <80}{'###'}", file=f)
+    print(f"{'###' : <80}{'###'}", file=f)
+    print(f"{diff_str : <80}{'###'}", file=f)
     print("#" * 83, file=f)
-    print(
-        "{}{}{}{}{}".format(
-            " ".ljust(19),
-            "Ref".rjust(20),
-            "Dev".rjust(20),
-            "Dev - Ref".rjust(14),
-            "% diff".rjust(10),
-        ),
-        file=f,
-    )
+    print(f"{'' : <19}{'Ref' : >20}{'Dev' : >20}{'Dev - Ref' : >14}{'% diff' : >10} {'no-diff'}", file=f)
 
     # ==================================================================
     # Print global masses for all species
@@ -521,7 +518,7 @@ def create_global_mass_table(
                 delta_p=met_and_masks["Dev_Delta_P"],
                 box_height=met_and_masks["Dev_BxHeight"],
             )
-
+            
         # ==============================================================
         # Print global masses for Ref and Dev
         # (we will mask out tropospheric boxes in util.print_totals)
@@ -531,13 +528,13 @@ def create_global_mass_table(
                 refarray,
                 devarray,
                 f,
-                masks=met_and_masks,
+                masks=met_and_masks
             )
         else:
             util.print_totals(
                 refarray,
                 devarray,
-                f,
+                f
             )
 
     # ==================================================================

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -270,7 +270,8 @@ def print_totals(
     # ==================================================================
     # Write output to file
     # ==================================================================
-    print(f"{display_name.ljust(14)} : {total_ref:18.6f}  {total_dev:18.6f}  {diff:12.6f}  {pctdiff:8.3f}  {zero_diff}", file=f)
+    print(f"{display_name.ljust(19)} : {total_ref:18.6f}  {total_dev:18.6f}  {diff:12.6f}  {pctdiff:8.3f}  {zero_diff}", file=f)
+
 
 def get_species_categories(
         benchmark_type="FullChemBenchmark"

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -222,7 +222,7 @@ def print_totals(
 
     # Special handling for totals
     if "_TOTAL" in diagnostic_name.upper():
-        print("-"*83, file=f)
+        print("-"*90, file=f)
 
     # ==================================================================
     # Sum the Ref array (or set to NaN if missing)
@@ -270,7 +270,7 @@ def print_totals(
     # ==================================================================
     # Write output to file
     # ==================================================================
-    print(f"{display_name.ljust(19)} : {total_ref:18.6f}  {total_dev:18.6f}  {diff:12.6f}  {pctdiff:8.3f}  {zero_diff}", file=f)
+    print(f"{display_name.ljust(19)}: {total_ref:18.6f}  {total_dev:18.6f}  {diff:12.6f}  {pctdiff:8.3f}  {zero_diff}", file=f)
 
 
 def get_species_categories(
@@ -2117,20 +2117,3 @@ def read_config_file(config_file, quiet=False):
         raise Exception(msg) from err
 
     return config
-
-
-def is_zero_diff(refdr, devdr):
-    """
-    Returns True if two DataArray objects contain identical data,
-    or False otherwise
-
-    Args:
-    -----
-    refdr (xarray DataArray)
-        The "Ref" DataArray object to be tested.
-    devdr (xarray DataArray)
-        The "Dev" DataArray object to be tested
-    """
-    if not np.array_equal(refdr.values, devdr.values):
-        return False
-    return True

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -843,7 +843,8 @@ def compare_varnames(
                              refdata and devdata, and that have lat,
                              lon, and level dimensions.
             commonvarsData   List of all commmon 2D or 3D data variables,
-                             excluding index variables.
+                             excluding index variables.  This is the
+                             list of "plottable" variables.
             refonly          List of 2D or 3D variables that are only
                              present in refdata.
             devonly          List of 2D or 3D variables that are only
@@ -855,37 +856,29 @@ def compare_varnames(
     refonly = [v for v in refvars if v not in devvars]
     devonly = [v for v in devvars if v not in refvars]
     dimmismatch = [v for v in commonvars if refdata[v].ndim != devdata[v].ndim]
+    # Assume plottable data has lon and lat
+    # This is OK for purposes of benchmarking
+    #  -- Bob Yantosca (09 Feb 2023)
+    commonvarsData = [
+        v for v in commonvars if (
+            ("lat" in refdata[v].dims or "Ydim" in refdata[v].dims)
+            and
+            ("lon" in refdata[v].dims or "Xdim" in refdata[v].dims)
+        )
+    ]        
     commonvarsOther = [
         v for v in commonvars if (
-          (
-            ("lat" not in refdata[v].dims or "Xdim" not in refdata[v].dims)
-            and
-            ("lon" not in refdata[v].dims or "Ydim" not in refdata[v].dims)
-            and
-            ("lev" not in refdata[v].dims)
-          )
-          or
-          (
-            ("hyam" in v or "hybm" in v)  # Omit these from plottable data
-          )
-        )
+           v not in commonvarsData
+        )    
     ]
     commonvars2D = [
         v for v in commonvars if (
-          ("lat" in refdata[v].dims or "Xdim" in refdata[v].dims)
-          and
-          ("lon" in refdata[v].dims or "Ydim" in refdata[v].dims)
-          and
-          ("lev" not in refdata[v].dims)
+            (v in commonvarsData) and ("lev" not in refdata[v].dims)
         )
     ]
     commonvars3D = [
         v for v in commonvars if (
-          ("lat" in refdata[v].dims or "Xdim" in refdata[v].dims)
-          and
-          ("lon" in refdata[v].dims or "Ydim" in refdata[v].dims)
-          and
-          ("lev" in refdata[v].dims)
+            (v in commonvarsData) and ("lev" in refdata[v].dims)
         )
     ]
 

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -2264,7 +2264,8 @@ def insert_text_into_file(
 
 def array_equals(
         refdata,
-        devdata
+        devdata,
+        dtype=np.float64
 ):
     """
     Tests two arrays for equality.  Useful for checking which
@@ -2276,6 +2277,9 @@ def array_equals(
         The first array to be checked.
     devdata: xarray DataArray or numpy ndarray
         The second array to be checked.
+    dtype : np.float32 or np.float64
+        The precision that will be used to make the evaluation.
+        Default: np.float64
 
     Returns:
     --------
@@ -2298,6 +2302,6 @@ def array_equals(
 
     # This method will work if the arrays hve different dimensions
     # but an element-by-element search will not!
-    refsum = np.sum(refdata, dtype=np.float64)
-    devsum = np.sum(devdata, dtype=np.float64)
-    return np.abs(devsum - refsum) > np.float64(0.0)
+    refsum = np.nansum(refdata, dtype=dtype)
+    devsum = np.nansum(devdata, dtype=dtype)
+    return (not np.abs(devsum - refsum) > dtype(0.0))


### PR DESCRIPTION
This is the companion PR to #199.  We propose to add additional text in the benchmark plots & tables to show which diagnostics are identical between benchmark Ref & Dev versions.

Tagging @msulprizio @lizziel 