### PR TITLE
Add stretching params to example regridding

### DIFF
--- a/docs/source/Regridding.rst
+++ b/docs/source/Regridding.rst
@@ -309,6 +309,10 @@ to demonstrate the stretched cubed-sphere regridding process:
    .. code-block:: console
 
       $ python -m gcpy.regrid_restart_file        \
+          --stretched-grid                        \
+          --stretch-factor 4.0                    \
+          --target-latitude 32.0                  \
+          --target-longitude -64.0                \
           GEOSChem.Restart.20190701_0000z.c48.nc4 \
           c48_to_c120_stretched_weights.nc        \
           GEOSChem.Restart.20190701_0000z.c48.nc4

--- a/gcpy/regrid_restart_file.py
+++ b/gcpy/regrid_restart_file.py
@@ -53,7 +53,11 @@ def file_path(path):
 
     """
     if not os.path.isfile(path):
-        raise argparse.ArgumentTypeError
+        error_message = (
+            f"File {path} does not exist! Please double-check the path"
+            " and make sure you have used the correct file extension"
+        )
+        raise argparse.ArgumentTypeError(error_message)
     return path
 
 


### PR DESCRIPTION
Corrects an error in the new regridding docs - adds grid stretching parameters to stretched grid regridding example.