### PR TITLE
Add C2H2 and C2H4 to emissions_species.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased 1.4.0]
+### Added
+- Added C2H2 and C2H4 to `emission_species.yml`
+- Updated `species_database.yml` for consistency with GEOS-Chem 14.2.0
+
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`
 

--- a/gcpy/emission_species.yml
+++ b/gcpy/emission_species.yml
@@ -5,6 +5,8 @@ FullChemBenchmark:
   BCPI: Tg
   BCPO: Tg
   BENZ: Tg
+  C2H2: Tg
+  C2H4: Tg
   C2H6: Tg
   C3H8: Tg
   CH2Br2: Tg

--- a/gcpy/species_database.yml
+++ b/gcpy/species_database.yml
@@ -453,6 +453,12 @@ BrSALA:
   FullName: Fine sea salt bromine
   Is_HygroGrowth: false
   MW_g: 79.90
+BUTDI:
+  Formula: C4H4O2
+  FullName: Butenedial
+  Is_Advected: true
+  Is_Gas: true
+  MW_g: 84.07
 BZCO3:
   Formula: C7H5O3
   FullName: Acyl peroxy radical from benzaldehyde
@@ -725,7 +731,7 @@ CH4_PROP: &CH4properties
   Formula: CH4
   Is_Advected: true
   Is_Gas: true
-  MW_g: 16.05
+  MW_g: 16.04
 CH4:
   << : *CH4properties
   Background_VV: 1.8e-6
@@ -926,6 +932,10 @@ CO2se:
   << : *CO2properties
   Background_VV: 1.0e-20
   FullName: Carbon dioxide from ship emissions
+CO2fromOH:
+  << : *CO2properties
+  Background_VV: 1.0e-20
+  FullName: Carbon dioxide loss by OH (carbon mechanism)
 CO_PROP: &COproperties
   Formula: CO
   Is_Advected: true
@@ -1015,6 +1025,14 @@ COus:
   << : *COproperties
   Background_VV: 1.0e-20
   FullName: Anthropogenic + biofuel CO emitted over the USA
+COfromCH4:
+  << : *COproperties
+  Background_VV: 1.0e-20
+  FullName: CO produced from methane oxidation (carbon mechanism)
+COfromNMVOC:
+  << : *COproperties
+  Background_VV: 1.0e-20
+  FullName: CO produced from non-methane VOCs oxidation (carbon mechanism)
 CSL:
   DD_F0: 1.0
   DD_Hstar: 4.2e+2
@@ -1068,6 +1086,18 @@ DSTAL4:
   << : *DST4properties
   FullName: Dust alkalinity, Reff = 4.5 microns
   MW_g: 29.0
+Dummy:
+  FullName: Dummy species (carbon mechanism)
+  Is_Gas: true
+  MW_g: 1.0
+DummyCH4:
+  << : *CH4properties
+  Background_VV: 1.8e-6
+  FullName: Methane (external input for carbon mechanism)
+DummyNMVOC:
+  << : *COproperties
+  Background_VV: 1.0e-20
+  FullName: CO produced from NMVOC oxidation (external input for carbon mechanism)
 EOH:
   DD_F0: 0.0
   DD_Hstar: 1.9e+2
@@ -1174,6 +1204,32 @@ FeF2:
   Formula: Fe
   Fullname: Iron on dust, Reff = 1.4 microns
   MW_g: 55.84
+FixedCl:
+  Formula: Cl
+  FullName: Atomic chlorine (external input for carbon mechanism)
+  Is_Advected: true
+  Is_Gas: true
+  MW_g: 35.45
+FixedOH:
+  Background_VV: 4.0e-15
+  Formula: OH
+  FullName: Hydroxyl radical (external input for carbon mechanism)
+  Is_Gas: true
+  MW_g: 17.01
+FURA:
+  DD_F0: 1.0
+  DD_Hstar: 1.80e-1
+  Formula: C4H4O
+  FullName: Furan
+  Henry_CR: 6100.0
+  Henry_K0: 1.80e-1
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: false
+  Is_WetDep: true
+  MW_g: 68.07
+  WD_RetFactor: 2.0e-2
 GlobEmis90dayTracer:
   FullName: Globally_emitted_tracer_with_90day_lifetime_and_100ppbv_maintained_mixing_ratio
   Is_Advected: true
@@ -1359,7 +1415,7 @@ HCOOH:
   MW_g: 46.03
   WD_RetFactor: 2.0e-2
 Hg0_PROP: &Hg0properties
-  DD_F0: 1.0e-5
+  DD_F0: 3.0e-5
   DD_Hstar: 0.11
   Formula: 'Hg'
   Is_Advected: true
@@ -1656,6 +1712,161 @@ HgP_usa:
 HgP_waf:
   << : *HgPproperties
   FullName: Particulate mercury from West Africa
+Hg_OTHER_PROP: &HgChemProperties
+  Henry_CR: 8.40e+03
+  Henry_K0: 1.40e+06
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  WD_RetFactor: 1.0
+HgBr: 
+  Fullname: HgBr
+  Formula: HgBr
+  Is_Advected: true
+  Is_Gas: true
+  Is_Photolysis: true
+  MW_g: 280.49
+HgBrNO2: 
+  Fullname: syn-HgBrONO
+  Formula: BrHgONO
+  Is_Advected: true
+  Is_DryDep: true
+  Is_Gas: true
+  Is_Photolysis: true
+  MW_g: 326.50
+HgBrHO2: 
+  << : *HgChemProperties
+  Fullname: HgBrHO2
+  Formula:  BrHgOOH
+  MW_g: 313.50
+HgBrBrO:
+  << : *HgChemProperties
+  Fullname: HgBrBrO
+  Formula: BrHgOBr
+  MW_g:  376.40
+HgBrClO: 
+  << : *HgChemProperties
+  Fullname: HgBrClO
+  Formula: BrHgOCl
+  MW_g: 332.00
+HgBrOH:
+  << : *HgChemProperties
+  Fullname: HgBrOH
+  Formula: BrHgOH
+  MW_g: 297.50
+HgBr2: 
+  << : *HgChemProperties
+  Fullname: HgBr2
+  Formula: HgBr2
+  MW_g:  360.40
+HgCl: 
+  Fullname: HgCl
+  Formula: HgCl
+  Is_Advected: true
+  Is_Gas: true
+  Is_Photolysis: true
+  Is_WetDep: false
+  MW_g: 236.04
+HgClNO2:
+  << : *HgChemProperties
+  Fullname: syn-HgClONO
+  Formula: ClHgONO
+  MW_g: 282.00
+HgClHO2:
+  WD_RetFactor: 1.0
+  << : *HgChemProperties
+  Fullname: HgClHO2
+  Formula: ClHgOOH
+  MW_g: 269.00
+  WD_RetFactor: 1.0
+HgClClO: 
+  << : *HgChemProperties
+  Fullname: HgClClO
+  Formula: ClHgOCl
+  MW_g: 287.50
+HgClBrO: 
+  << : *HgChemProperties
+  Fullname: HgClBrO
+  Formula: ClHgOBr
+  MW_g: 332.00
+HgClBr: 
+  << : *HgChemProperties
+  Fullname: HgClBr
+  Formula: HgBrCl
+  MW_g: 316.00
+HgClOH: 
+  << : *HgChemProperties
+  Fullname: HgClOH
+  Formula: ClHgOH
+  MW_g: 253.00
+HgOH: 
+  Fullname: HgOH
+  Formula: HgOH
+  Is_Advected: true
+  Is_Gas: true
+  Is_Photolysis: true
+  MW_g: 201.00
+HgOHNO2: 
+  << : *HgChemProperties
+  Fullname: syn-HgOHONO
+  Formula: HOHgONO
+  MW_g:  263.60
+HgOHHO2: 
+  << : *HgChemProperties
+  Fullname: HgOHHO2
+  Formula: HOHgOOH
+  MW_g:  250.60
+HgOHClO: 
+  << : *HgChemProperties
+  Fullname: HgBrClO
+  Formula: HOHgOCl
+  MW_g:  269.0000
+HgOHBrO: 
+  << : *HgChemProperties
+  Fullname: HgOHBrO
+  Formula: HOHgOBr
+  MW_g: 313.5000
+HgOHOH: 
+  << : *HgChemProperties
+  Fullname: HgOH2
+  Formula: HOHgOH
+  MW_g:  234.60
+HgCl2: 
+  << : *HgChemProperties
+  Fullname: HgCl2
+  Formula: HgCl2
+  MW_g:  271.5000
+Hg2ClP: 
+  Fullname: Hg(II) chloride salts on sea-salt aerosols
+  Formula: HgCln
+  Is_Aerosol: true
+  Is_DryDep: true
+  Is_HygroGrowth: false
+  Is_WetDep: true
+  MW_g: 201.00
+  WD_AerScavEff: 1.0
+  WD_KcScaleFac: [1.0, 0.5, 1.0]
+  WD_RainoutEff: [1.0, 1.0, 1.0]
+Hg2ORGP: 
+  Fullname: Hg(II) organic complex in aerosols
+  Formula: R-Hg
+  Is_Advected: true
+  Is_Aerosol: true
+  Is_DryDep: true
+  Is_Photolysis: true
+  Is_WetDep: true
+  MW_g: 201.00
+  WD_AerScavEff: 1.0
+  WD_KcScaleFac: [1.0, 0.5, 1.0]
+  WD_RainoutEff: [1.0, 1.0, 1.0]
+Hg2STRP: 
+  Fullname: Hg(II) in stratospheric aerosols
+  Formula: Hg2+
+  Is_Advected: true
+  Is_Aerosol: true
+  MW_g: 201.00
 HI:
   DD_F0: 0.0
   DD_Hstar: 2.35e+16
@@ -2466,7 +2677,7 @@ LBRO2N:
 LCH4:
   FullName: Dummy species to track loss rate of CH4
   Is_Gas: true
-  MW_g: 16.05
+  MW_g: 16.04
 LCO:
   FullName: Dummy species to track loss rate of CO
   Is_Gas: true
@@ -3161,6 +3372,7 @@ NITs:
   FullName: Inorganic nitrates on surface of seasalt aerosol
   Is_Photolysis: true
   MW_g: 31.4
+  WD_CoarseAer: true
 'NO':
   Background_VV: 4.0e-13
   Formula: 'NO'
@@ -4196,6 +4408,7 @@ SO4s:
   << : *SALCproperties
   FullName: Sulfate on surface of seasalt aerosol
   MW_g: 31.4
+  WD_CoarseAer: true
 SOAGX:
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0


### PR DESCRIPTION
Mat Evans pointed out C2H2 and C2H4 were missing from the emissions tables in 1-month and 1-year full-chemistry benchmark output. This is corrected by listing these species in emission_species.yml.

Here we also update species_database.yml to be consistent with the current file in the GEOS-Chem 14.2.0 development branch.