### PR TITLE
Update run_benchmark.py to allow for other benchmark types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `species_database.yml` for consistency with GEOS-Chem 14.2.0
 - Added `.github/ISSUE_TEMPLATE/config.yml` file w/ Github issue options
 - Added `CONTRIBUTING.md` and `SUPPORT.md`, replacing `docs/source/Contributing.rst` and `docs/source/Report_Request.rst`
+- Added option to pass the benchmark type to plotting routines
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`
@@ -27,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New functions in `benchmark.py` and `util.py` to facilitate printing of the species/emissions/inventories that differ between Dev & Ref versions.
 - Added new RTD documentation for installing Conda 4.12.0 with Miniconda
 - Added GCHP regridding environnment file `docs/environment_files/gchp_regridding.yml`
+- Added new benchmark type CH4Benchmark
 
 ### Changed
 - Applied cleanup susggestions from pylint to `benchmark.py`, `util.py`, `plot.py`, `oh_metrics.py`, `ste_flux.py`
@@ -62,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed obsolete environment.yml files (@yantosca)
 - Added requirements.yml to docs folder for Sphinx/RTD documentation (@yantosca)
 - New regridding script `regrid_restart_file.py` (@liambindle)
+
 ### Changed
 - Fixed several issues in benchmarking scripts (@laestrada, @lizziel, @yantosca)
   - Fixed bug in `budget_ox.py`; The drydep loss of Ox for GCHP was 12x too high

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -479,8 +479,8 @@ def run_benchmark_default(config):
                 dst=gcc_vs_gcc_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 plot_by_spc_cat=config["options"]["outputs"]["plot_options"][
-                    "by_spc_cat"
-                ],
+                    "by_spc_cat"],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gcc_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
@@ -505,11 +505,10 @@ def run_benchmark_default(config):
                 dst=gcc_vs_gcc_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 plot_by_spc_cat=config["options"]["outputs"]["plot_options"][
-                    "by_spc_cat"
-                ],
+                    "by_spc_cat"],
                 plot_by_hco_cat=config["options"]["outputs"]["plot_options"][
-                    "by_hco_cat"
-                ],
+                    "by_hco_cat"],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gcc_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
@@ -534,6 +533,7 @@ def run_benchmark_default(config):
                 dst=gcc_vs_gcc_resultsdir,
                 ref_interval=[gcc_ref_sec_diff],
                 dev_interval=[gcc_dev_sec_diff],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
             )


### PR DESCRIPTION
Calls to make_benchmark_conc_plots, make_benchmark_emis_plots, and make_benchmark_emis_tables have been updated to pass benchmark_type as defined in the configuration file. This allows these plots and tables to be created for benchmark types other than FullChemBenchmark. Previously this update was only made for 1-year benchmarks (in run_1yr_fullchem_benchmark.py) but this update allows plots for benchmarks of other durations.