### PR TITLE
Allow for other benchmark types for GCHP plotting as well

### DIFF
--- a/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+ #!/usr/bin/env python
 """
 run_1yr_fullchem_benchmark.py:
     Driver script for creating benchmark plots and testing gcpy
@@ -962,6 +962,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "plot_options"]["by_spc_cat"],
                 plot_by_hco_cat=config["options"]["outputs"][
                     "plot_options"]["by_hco_cat"],
+                benchmark_type=bmk_type,
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
             )
@@ -986,6 +987,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "plot_options"]["by_spc_cat"],
                     plot_by_hco_cat=config["options"]["outputs"][
                         "plot_options"]["by_hco_cat"],
+                    benchmark_type=bmk_type,
                     overwrite=True,
                     spcdb_dir=spcdb_dir,
                 )
@@ -1020,7 +1022,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 dst=gchp_vs_gcc_resultsdir,
                 ref_interval=sec_per_month_ref,
                 dev_interval=sec_per_month_dev,
-                overwrite=True,
+                benchmark_type=bmk_type,
+                verwrite=True,
                 spcdb_dir=spcdb_dir,
             )
 
@@ -1508,6 +1511,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "plot_options"]["by_spc_cat"],
                 plot_by_hco_cat=config["options"]["outputs"][
                     "plot_options"]["by_hco_cat"],
+                benchmark_type=bmk_type,
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
             )
@@ -1533,6 +1537,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "plot_options"]["by_spc_cat"],
                     plot_by_hco_cat=config["options"]["outputs"][
                         "plot_options"]["by_hco_cat"],
+                    benchmark_type=bmk_type,
                     overwrite=True,
                     spcdb_dir=spcdb_dir,
                 )
@@ -1570,6 +1575,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 dst=gchp_vs_gchp_resultsdir,
                 ref_interval=sec_per_month_ref,
                 dev_interval=sec_per_month_dev,
+                benchmark_type=bmk_type,
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
             )

--- a/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -1023,7 +1023,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 ref_interval=sec_per_month_ref,
                 dev_interval=sec_per_month_dev,
                 benchmark_type=bmk_type,
-                verwrite=True,
+                overwrite=True,
                 spcdb_dir=spcdb_dir,
             )
 

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -793,6 +793,7 @@ def run_benchmark_default(config):
                 weightsdir=config["paths"]["weights_dir"],
                 plot_by_spc_cat=config["options"]["outputs"]["plot_options"][
                     "by_spc_cat"
+                benchmark_type=config["options"]["bmk_type"],
                 ],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gcc_sigdiff,
@@ -829,6 +830,7 @@ def run_benchmark_default(config):
                 plot_by_hco_cat=config["options"]["outputs"]["plot_options"][
                     "by_hco_cat"
                 ],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
@@ -859,6 +861,7 @@ def run_benchmark_default(config):
                 dst=gchp_vs_gcc_resultsdir,
                 ref_interval=[gcc_dev_sec_diff],
                 dev_interval=[gchp_dev_sec_diff],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 devmet=devmet,
                 spcdb_dir=spcdb_dir,
@@ -1148,6 +1151,7 @@ def run_benchmark_default(config):
                 weightsdir=config["paths"]["weights_dir"],
                 plot_by_spc_cat=config["options"]["outputs"]["plot_options"][
                     "by_spc_cat"
+                benchmark_type=config["options"]["bmk_type"],
                 ],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gchp_sigdiff,
@@ -1190,6 +1194,7 @@ def run_benchmark_default(config):
                 plot_by_hco_cat=config["options"]["outputs"]["plot_options"][
                     "by_hco_cat"
                 ],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gchp_sigdiff,
                 spcdb_dir=spcdb_dir,
@@ -1226,6 +1231,7 @@ def run_benchmark_default(config):
                 dst=gchp_vs_gchp_resultsdir,
                 ref_interval=[gchp_ref_sec_diff],
                 dev_interval=[gchp_dev_sec_diff],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 refmet=refmet,
                 devmet=devmet,
@@ -1486,6 +1492,7 @@ def run_benchmark_default(config):
                 diff_of_diffs_devstr,
                 dst=diff_of_diffs_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
+                benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 use_cmap_RdBu=True,
                 second_ref=gcc_dev,


### PR DESCRIPTION
Building off of PR #212, we now pass benchmark_type to make_benchmark_conc_plots, make_benchmark_emis_plots, and make_benchmark_emis_tables for GCHP vs GCC comparisons, GCHP version comparisons, and diff-of-diffs in both run_benchmark.py and run_1yr_fullchem_benchmark.py.

This addresses https://github.com/geoschem/gcpy/pull/212#issuecomment-1488695936