### PR TITLE
Optional mass accumulation table in 1-month benchmark

### DIFF
--- a/benchmark/1mo_benchmark.yml
+++ b/benchmark/1mo_benchmark.yml
@@ -105,6 +105,7 @@ options:
     plot_jvalues: True
     plot_aod: True
     mass_table: True
+    mass_accum_table: False
     ops_budget_table: False
     OH_metrics: True
     ste_table: True # GCC only

--- a/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/benchmark/modules/run_1yr_tt_benchmark.py
@@ -294,6 +294,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
         print(" - Radionuclides budget table")
     if config["options"]["outputs"]["operations_budget"]:
         print(" - Operations budget table")
+    if config["options"]["outputs"]["mass_accumulation"]:
+        print(" - Mass accumulation table")
     if config["options"]["outputs"]["ste_table"]:
         print(" - Table of strat-trop exchange")
     if config["options"]["outputs"]["cons_table"]:
@@ -1001,6 +1003,13 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 compute_accum=False,
                 dst=gchp_vs_gchp_tablesdir,
             )
+
+        # ==================================================================
+        # GCHP vs GCHP mass accumulation table
+        # ==================================================================
+        if config["options"]["outputs"]["mass_accumulation"]:
+            print("\n%%% Creating GCHP vs. GCHP mass accumulation table %%%")
+
 
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create mass conservations tables for GCC and GCHP

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -402,6 +402,8 @@ def run_benchmark_default(config):
         print(" - Table of emissions totals by spc and inventory")
     if config["options"]["outputs"]["mass_table"]:
         print(" - Table of species mass")
+    if config["options"]["outputs"]["mass_accum_table"]:
+        print(" - Table of species mass accumulation")
     if config["options"]["outputs"]["OH_metrics"]:
         print(" - Table of OH metrics")
     if config["options"]["outputs"]["ste_table"]:
@@ -602,6 +604,31 @@ def run_benchmark_default(config):
                 config["data"]["dev"]["gcc"]["version"],
                 dst=gcc_vs_gcc_tablesdir,
                 overwrite=True,
+                spcdb_dir=spcdb_dir,
+            )
+
+        # ==================================================================
+        # GCC vs GCC global mass accumulation tables
+        # ==================================================================
+        if config["options"]["outputs"]["mass_accum_table"]:
+            print("\n%%% Creating GCC vs. GCC mass accumulation tables %%%")
+
+            # Filepaths for start and end restart files
+            refs = get_filepath(gcc_vs_gcc_refrst, "Restart", gcc_ref_date)
+            devs = get_filepath(gcc_vs_gcc_devrst, "Restart", gcc_dev_date)
+            refe = get_filepath(gcc_vs_gcc_refrst, "Restart", gcc_end_ref_date)
+            deve = get_filepath(gcc_vs_gcc_devrst, "Restart", gcc_end_dev_date)
+
+            # Create tables
+            bmk.make_benchmark_mass_accumulation_tables(
+                refs,
+                refe,
+                config["data"]["ref"]["gcc"]["version"],
+                devs,
+                deve,
+                config["data"]["dev"]["gcc"]["version"],
+                overwrite=True,
+                dst=gcc_vs_gcc_tablesdir,
                 spcdb_dir=spcdb_dir,
             )
 

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -619,14 +619,24 @@ def run_benchmark_default(config):
             refe = get_filepath(gcc_vs_gcc_refrst, "Restart", gcc_end_ref_date)
             deve = get_filepath(gcc_vs_gcc_devrst, "Restart", gcc_end_dev_date)
 
+            # Get period strings
+            refs_str = np.datetime_as_string(gcc_ref_date, unit="s")
+            devs_str = np.datetime_as_string(gcc_dev_date, unit="s")
+            refe_str = np.datetime_as_string(gcc_end_ref_date, unit="s")
+            deve_str = np.datetime_as_string(gcc_end_dev_date, unit="s")
+            refperiod = refs_str + ' - ' + refe_str
+            devperiod = devs_str + ' - ' + deve_str
+
             # Create tables
             bmk.make_benchmark_mass_accumulation_tables(
                 refs,
                 refe,
                 config["data"]["ref"]["gcc"]["version"],
+                refperiod,
                 devs,
                 deve,
                 config["data"]["dev"]["gcc"]["version"],
+                devperiod,
                 overwrite=True,
                 dst=gcc_vs_gcc_tablesdir,
                 spcdb_dir=spcdb_dir,
@@ -980,6 +990,63 @@ def run_benchmark_default(config):
                 gchp_vs_gcc_devstr,
                 dst=gchp_vs_gcc_tablesdir,
                 overwrite=True,
+                spcdb_dir=spcdb_dir,
+            )
+
+        # ==================================================================
+        # GCHP vs GCC global mass accumulation tables
+        # ==================================================================
+        if config["options"]["outputs"]["mass_accum_table"]:
+            print("\n%%% Creating GCHP vs. GCC mass accumulation tables %%%")
+
+            # Filepaths for start and end restart files
+            refs = get_filepath(
+                gchp_vs_gcc_refrst,
+                "Restart",
+                gcc_dev_date
+            )
+            devs = get_filepath(
+                gchp_vs_gcc_devrst,
+                "Restart",
+                gchp_dev_date,
+                is_gchp=True,
+                gchp_res=config["data"]["dev"]["gchp"]["resolution"],
+                gchp_is_pre_14_0=config["data"]["dev"]["gchp"]["is_pre_14.0"]
+            )
+            refe = get_filepath(
+                gchp_vs_gcc_refrst,
+                "Restart",
+                gcc_end_dev_date
+            )
+            deve = get_filepath(
+                gchp_vs_gcc_devrst,
+                "Restart",
+                gchp_end_dev_date,
+                is_gchp=True,
+                gchp_res=config["data"]["dev"]["gchp"]["resolution"],
+                gchp_is_pre_14_0=config["data"]["dev"]["gchp"]["is_pre_14.0"]
+            )
+
+            # Get period strings
+            refs_str = np.datetime_as_string(gcc_dev_date, unit="s")
+            devs_str = np.datetime_as_string(gchp_dev_date, unit="s")
+            refe_str = np.datetime_as_string(gcc_end_dev_date, unit="s")
+            deve_str = np.datetime_as_string(gchp_end_dev_date, unit="s")
+            refperiod = refs_str + ' - ' + refe_str
+            devperiod = devs_str + ' - ' + deve_str
+
+            # Create tables
+            bmk.make_benchmark_mass_accumulation_tables(
+                refs,
+                refe,
+                config["data"]["dev"]["gcc"]["version"],
+                refperiod,
+                devs,
+                deve,
+                config["data"]["dev"]["gchp"]["version"],
+                devperiod,
+                overwrite=True,
+                dst=gchp_vs_gcc_tablesdir,
                 spcdb_dir=spcdb_dir,
             )
 
@@ -1363,6 +1430,69 @@ def run_benchmark_default(config):
                 gchp_vs_gchp_devstr,
                 dst=gchp_vs_gchp_tablesdir,
                 overwrite=True,
+                spcdb_dir=spcdb_dir,
+            )
+
+        # ==================================================================
+        # GCHP vs GCHP global mass accumulation tables
+        # ==================================================================
+        if config["options"]["outputs"]["mass_accum_table"]:
+            print("\n%%% Creating GCHP vs. GCHP mass accumulation tables %%%")
+
+            # Filepaths for start and end restart files
+            refs = get_filepath(
+                gchp_vs_gchp_refrst,
+                "Restart",
+                gchp_ref_date,
+                is_gchp=True,
+                gchp_res=config["data"]["ref"]["gchp"]["resolution"],
+                gchp_is_pre_14_0=config["data"]["ref"]["gchp"]["is_pre_14.0"]
+            )
+            devs = get_filepath(
+                gchp_vs_gchp_devrst,
+                "Restart",
+                gchp_dev_date,
+                is_gchp=True,
+                gchp_res=config["data"]["dev"]["gchp"]["resolution"],
+                gchp_is_pre_14_0=config["data"]["dev"]["gchp"]["is_pre_14.0"]
+            )
+            refe = get_filepath(
+                gchp_vs_gchp_refrst,
+                "Restart",
+                gchp_end_ref_date,
+                is_gchp=True,
+                gchp_res=config["data"]["ref"]["gchp"]["resolution"],
+                gchp_is_pre_14_0=config["data"]["ref"]["gchp"]["is_pre_14.0"]
+            )
+            deve = get_filepath(
+                gchp_vs_gchp_devrst,
+                "Restart",
+                gchp_end_dev_date,
+                is_gchp=True,
+                gchp_res=config["data"]["dev"]["gchp"]["resolution"],
+                gchp_is_pre_14_0=config["data"]["dev"]["gchp"]["is_pre_14.0"]
+            )
+
+            # Get period strings
+            refs_str = np.datetime_as_string(gchp_ref_date, unit="s")
+            devs_str = np.datetime_as_string(gchp_dev_date, unit="s")
+            refe_str = np.datetime_as_string(gchp_end_ref_date, unit="s")
+            deve_str = np.datetime_as_string(gchp_end_dev_date, unit="s")
+            refperiod = refs_str + ' - ' + refe_str
+            devperiod = devs_str + ' - ' + deve_str
+
+            # Create tables
+            bmk.make_benchmark_mass_accumulation_tables(
+                refs,
+                refe,
+                config["data"]["ref"]["gchp"]["version"],
+                refperiod,
+                devs,
+                deve,
+                config["data"]["dev"]["gchp"]["version"],
+                devperiod,
+                overwrite=True,
+                dst=gchp_vs_gchp_tablesdir,
                 spcdb_dir=spcdb_dir,
             )
 

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -282,7 +282,7 @@ def print_totals(
         pctdiff = np.nan
     else:
         pctdiff = ((total_dev - total_ref) / total_ref) * 100.0
-        if total_ref < 1.0e-15:
+        if np.abs(total_ref) < 1.0e-15:
             pctdiff = np.nan
 
     # ==================================================================


### PR DESCRIPTION
**Name:** Lizzie Lundgren
**Institution:** Harvard University

**Description:**

The PR adds a mass accumulation table (full column only) as a 1-month benchmark option. The mass accumulation table compares the difference in mass change for each species across two different runs, ref and dev. The mass change per species is computed as the difference between start and end based on values in the restart files (end restart mass minus start restart mass). Concentrations are converted to mass in the same way as done for the benchmark mass tables.

Here is an example of what the accumulation table looks like.

```
#########################################################################################
### Global mass accumulation (Gg) at end of simulation (Trop + Strat)                 ###
###                                                                                   ###
### Computed as change in instantaneous mass across period                            ###
###                                                                                   ###
### Ref = GCC 14.2.0                                                                  ###
### Dev = GCHP 14.2.0                                                                 ###
###                                                                                   ###
### Ref period: 2019-07-01T00:00:00 - 2019-07-01T01:00:00                             ###
### Dev period: 2019-07-01T00:00:00 - 2019-07-01T01:00:00                             ###
###                                                                                   ###
### Dev and Ref show 320 differences                                                  ###
#########################################################################################
                                    Ref                 Dev     Dev - Ref    % diff diffs
A3O2               :           0.010931            0.011537      0.000606     5.545   *
ACET               :          -0.826196           -1.264580     -0.438384    53.061   *
ACTA               :           2.208566            2.235849      0.027283     1.235   *
AERI               :           0.007904            0.008448      0.000544     6.880   *
ALD2               :           2.804017            2.823217      0.019200     0.685   *
ALK4               :           1.063624            0.743184     -0.320439   -30.127   *
AONITA             :          -0.027543           -0.015672      0.011872   -43.103   *
AROMP4             :           0.052310            0.056877      0.004567     8.731   *
AROMP5             :           0.048970            0.053550      0.004579     9.351   *
AROMRO2            :           0.008096            0.009819      0.001723    21.287   *
```


This table can be used with the operations budget table to look at changes in mass across a run, and to validate the operations budget diagnostics. Its values correspond to the ACCUMULATION entries in the operations budget table and is an alternative (and cheaper) way to get those values.

The table is currently only produced for full column and is limited to the 1-month benchmark. It can be expanded in a future PR if there is demand.

**Expected differences:**

None. This table is off by default in the 1-month benchmark yaml configuration file.