### PR TITLE
Bug fixes in transport tracer benchmark code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`
+- Fixed bug in transport tracer benchmark mass conservation table file write
 
 ## [1.3.3] -- 2023-03-09
 ### Added

--- a/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/benchmark/modules/run_1yr_tt_benchmark.py
@@ -294,8 +294,6 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
         print(" - Radionuclides budget table")
     if config["options"]["outputs"]["operations_budget"]:
         print(" - Operations budget table")
-    if config["options"]["outputs"]["mass_accumulation"]:
-        print(" - Mass accumulation table")
     if config["options"]["outputs"]["ste_table"]:
         print(" - Table of strat-trop exchange")
     if config["options"]["outputs"]["cons_table"]:
@@ -1003,13 +1001,6 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 compute_accum=False,
                 dst=gchp_vs_gchp_tablesdir,
             )
-
-        # ==================================================================
-        # GCHP vs GCHP mass accumulation table
-        # ==================================================================
-        if config["options"]["outputs"]["mass_accumulation"]:
-            print("\n%%% Creating GCHP vs. GCHP mass accumulation table %%%")
-
 
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create mass conservations tables for GCC and GCHP

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -5071,10 +5071,10 @@ def make_benchmark_mass_conservation_table(
         print(' ', file=f)
         print(' Summary', file=f)
         print(' ' + '-' * 30, file=f)
-        print(f" Max mass =  {max_mass : 2.13f} Tg")
-        print(f" Min mass =  {min_mass : 2.13f} Tg")
-        print(f" Abs diff =  {absdiff : >16.3f} g")
-        print(f" Pct diff =  {pctdiff : >16.10f} %")
+        print(f" Max mass =  {max_mass : 2.13f} Tg", file=f)
+        print(f" Min mass =  {min_mass : 2.13f} Tg", file=f)
+        print(f" Abs diff =  {absdiff : >16.3f} g", file=f)
+        print(f" Pct diff =  {pctdiff : >16.10f} %", file=f)
 
     gc.collect()
 


### PR DESCRIPTION
This PR includes two fixes for the transport tracer 1-year benchmark:

1. Fix print commands for last four lines of mass conservation table. Previously the lines were written to the terminal rather than the output file.
2. Remove references to mass accumulation table in the transport tracer benchmark python file. Those came in by mistake and the mass accumulation table should only be in the 1-month benchmark files.