### PR TITLE
Update species database and benchmark categories for TransportTracer changes in GEOS-Chem 14.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The GitHub PR template is now named `./github/PULL_REQUEST_TEMPLATE.md`
 - Now specify package `requests-2.31.0` in `environment.py` (fixes a security issue)
 - Updated badge links in `README.md`
+- Updated species_database.yml for consistency with GEOS-Chem 14.2.0
+- Renamed TransportTracers species in `benchmark_categories.yml` and in documentation
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`

--- a/docs/source/Plotting.rst
+++ b/docs/source/Plotting.rst
@@ -967,10 +967,9 @@ species categories is denoted in :file:`benchmark_categories.yml`
          Peroxides: MP
       Sulfur: SOx, DMS, OCS, SO2, SO4
    TransportTracersBenchmark:
-      RnPbBeTracers: Rn222, Pb210, Pb210Strat, Be7, Be7Strat, Be10, Be10Strat
-      PassiveTracers: PassiveTracer, SF6Tracer, CH3ITracer, COAnthroEmis25dayTracer,
-          COAnthroEmis50dayTracer, COUniformEmis25dayTracer, GlobEmis90dayTracer,
-          NHEmis90dayTracer, SHEmis90dayTracer
+      RnPbBeTracers: Rn222, Pb210, Pb210s, Be7, Be7s, Be10, Be10s
+      TransportTracers: PassiveTracer, SF6, CH3I, aoa, aoa_bl, aoa_nh,
+          CO_25, CO_50, e90, e90_s, e90_n, st80_25, stOX
 
    """
 

--- a/gcpy/benchmark_categories.yml
+++ b/gcpy/benchmark_categories.yml
@@ -220,22 +220,26 @@ TransportTracersBenchmark:
     RnPbBeTracers:
       - Rn222
       - Pb210
-      - Pb210Strat
+      - Pb210s
       - Be7
-      - Be7Strat
+      - Be7s
       - Be10
-      - Be10Strat
-  PassiveTracers:
-    PassiveTracers:
+      - Be10s
+  TransportTracers:
+    TransportTracers:
       - PassiveTracer
-      - SF6Tracer
-      - CH3ITracer
-      - COAnthroEmis25dayTracer
-      - COAnthroEmis50dayTracer
-      - COUniformEmis25dayTracer
-      - GlobEmis90dayTracer
-      - NHEmis90dayTracer
-      - SHEmis90dayTracer
+      - SF6
+      - CH3I
+      - aoa
+      - aoa_bl
+      - aoa_nh
+      - CO_25
+      - CO_50
+      - e90
+      - e90_n
+      - e90_s
+      - st80_25
+      - stOX
   WetLossConv:
     WetLossConv:
       - Pb210

--- a/gcpy/species_database.yml
+++ b/gcpy/species_database.yml
@@ -136,55 +136,35 @@ ALK4:
   Is_Advected: true
   Is_Gas: true
   MW_g: 58.12
+aoa_PROP: &aoaproperties
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Snk_Mode: constant
+  Snk_Value: 0
+  Src_Add: true
+  Src_Horiz: all
+  Src_Mode: constant
+  Src_Units: timestep
+  Src_Value: 1
+  Src_Vert: all
+  Units: days
 aoa:
+  << : *aoaproperties
   FullName: Age of air uniform source tracer
-  Is_Advected: true
-  Is_Gas: true
-  Is_Tracer: true
   Snk_Horiz: all
-  Snk_Mode: constant
-  Snk_Value: 0
   Snk_Vert: surface
-  Src_Add: true
-  Src_Horiz: all
-  Src_Mode: constant
-  Src_Units: timestep
-  Src_Value: 1
-  Src_Vert: all
-  Units: days
 aoa_bl:
+  << : *aoaproperties
   FullName: Age of air uniform source tracer with sink restricted to the boundary layer
-  Is_Advected: true
-  Is_Gas: true
-  Is_Tracer: true
   Snk_Horiz: all
-  Snk_Mode: constant
-  Snk_Value: 0
   Snk_Vert: boundary_layer
-  Src_Add: true
-  Src_Horiz: all
-  Src_Mode: constant
-  Src_Units: timestep
-  Src_Value: 1
-  Src_Vert: all
-  Units: days
 aoa_nh:
+  << : *aoaproperties
   FullName: Age of air uniform source tracer with surface sink restricted to a zone in the northern hemisphere
-  Is_Advected: true
-  Is_Gas: true
-  Is_Tracer: true
   Snk_Horiz: lat_zone
   Snk_Lats: [30.0, 50.0]
-  Snk_Mode: constant
-  Snk_Value: 0
   Snk_Vert: surface
-  Src_Add: true
-  Src_Horiz: all
-  Src_Mode: constant
-  Src_Units: timestep
-  Src_Value: 1
-  Src_Vert: all
-  Units: days
 AONITA:
   DD_F0: 1.0
   DD_Hstar: 2.9e+3

--- a/gcpy/species_database.yml
+++ b/gcpy/species_database.yml
@@ -136,6 +136,55 @@ ALK4:
   Is_Advected: true
   Is_Gas: true
   MW_g: 58.12
+aoa:
+  FullName: Age of air uniform source tracer
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: constant
+  Snk_Value: 0
+  Snk_Vert: surface
+  Src_Add: true
+  Src_Horiz: all
+  Src_Mode: constant
+  Src_Units: timestep
+  Src_Value: 1
+  Src_Vert: all
+  Units: days
+aoa_bl:
+  FullName: Age of air uniform source tracer with sink restricted to the boundary layer
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: constant
+  Snk_Value: 0
+  Snk_Vert: boundary_layer
+  Src_Add: true
+  Src_Horiz: all
+  Src_Mode: constant
+  Src_Units: timestep
+  Src_Value: 1
+  Src_Vert: all
+  Units: days
+aoa_nh:
+  FullName: Age of air uniform source tracer with surface sink restricted to a zone in the northern hemisphere
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Snk_Horiz: lat_zone
+  Snk_Lats: [30.0, 50.0]
+  Snk_Mode: constant
+  Snk_Value: 0
+  Snk_Vert: surface
+  Src_Add: true
+  Src_Horiz: all
+  Src_Mode: constant
+  Src_Units: timestep
+  Src_Value: 1
+  Src_Vert: all
+  Units: days
 AONITA:
   DD_F0: 1.0
   DD_Hstar: 2.9e+3
@@ -314,7 +363,14 @@ Be_PROP: &Beproperties
   Is_Aerosol: true
   Is_DryDep: true
   Is_RadioNuclide: true
+  Is_Tracer: true
   Is_WetDep: true
+# Comment out tracer-specific code for now and use RnPbBe_mod.F90
+#  Snk_Horiz: all
+#  Snk_Mode: halflife
+#  Snk_Vert: all
+#  Src_Add: true
+#  Src_Mode: HEMCO
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
@@ -324,21 +380,29 @@ Be10:
   Formula: Be10
   FullName: Beryllium-10 isotope
   MW_g: 10.0
-Be10Strat:
+#  Snk_Period: 5.84e8
+#  Src_Vert: all
+Be10s:
   << : *Beproperties
   Formula: Be10
-  FullName: Beryllium-10 isotope in stratosphere
+  FullName: Beryllium-10 isotope stratospheric-source tracer
   MW_g: 10.0
+#  Snk_Period: 5.84e8
+#  Src_Vert: stratosphere
 Be7:
   << : *Beproperties
   Formula: Be7
   FullName: Beryllium-7 isotope
   MW_g: 7.0
-Be7Strat:
+#  Snk_Period: 53.3
+#  Src_Vert: all
+Be7s:
   << : *Beproperties
   Formula: Be7
-  FullName: Beryllium-7 isotope in stratosphere
+  FullName: Beryllium-7 isotope stratospheric-source tracer
   MW_g: 7.0
+#  Snk_Period: 53.3
+#  Src_Vert: stratosphere
 BENZ:
   Formula: C6H6
   FullName: Benzene
@@ -714,6 +778,7 @@ CH3Cl:
   Is_Photolysis: true
   MW_g: 50.45
 CH3I:
+  Background_VV: 1.0e-20
   Formula: CH3I
   FullName: Methyl iodide
   Henry_CR: 3.6e+3
@@ -721,11 +786,13 @@ CH3I:
   Is_Advected: true
   Is_Gas: true
   Is_Photolysis: true
-  MW_g: 141.94
-CH3ITracer:
-  FullName: Methyl_iodide
-  Is_Advected: true
-  Is_Gas: true
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: efolding
+  Snk_Period: 5
+  Snk_Vert: all
+  Src_Add: true
+  Src_Mode: HEMCO
   MW_g: 141.94
 CH4_PROP: &CH4properties
   Formula: CH4
@@ -768,6 +835,10 @@ CH4_OTA:
   << : *CH4properties
   Background_VV: 1.0e-20
   FullName: Methane from other anthropogenic emissions
+CH4_RES:
+  << : *CH4properties
+  Background_VV: 1.0e-20
+  FullName: Methane from hydroelectric reservoir emissions
 CH4_RIC:
   << : *CH4properties
   Background_VV: 1.0e-20
@@ -949,14 +1020,28 @@ COacet:
   << : *COproperties
   Background_VV: 1.0e-20
   FullName: CO produced from acetone oxidation
-COAnthroEmis25dayTracer:
+CO_25:
   << : *COproperties
   Background_VV: 1.0e-20
-  FullName: Anthropogenic_CO_with_25day_lifetime
-COAnthroEmis50dayTracer:
+  FullName: Anthropogenic CO 25 day tracer
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: efolding
+  Snk_Period: 25
+  Snk_Vert: all
+  Src_Add: true
+  Src_Mode: HEMCO
+CO_50:
   << : *COproperties
   Background_VV: 1.0e-20
-  FullName: Anthropogenic_CO_with_50day_lifetime
+  FullName: Anthropogenic CO 50 day tracer
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: efolding
+  Snk_Period: 50
+  Snk_Vert: all
+  Src_Add: true
+  Src_Mode: HEMCO
 COasia:
   << : *COproperties
   Background_VV: 1.0e-20
@@ -1098,6 +1183,35 @@ DummyNMVOC:
   << : *COproperties
   Background_VV: 1.0e-20
   FullName: CO produced from NMVOC oxidation (external input for carbon mechanism)
+e90_PROP: &e90properties
+  Background_VV: 1.0e-20
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  MW_g: 1.0
+  Snk_Horiz: all
+  Snk_Mode: efolding
+  Snk_Period: 90
+  Snk_Vert: all
+  Src_Add: true
+  Src_Mode: maintain_mixing_ratio
+  Src_Units: ppbv
+  Src_Value: 100
+  Src_Vert: surface
+e90:
+  << : *e90properties
+  FullName: Constant burden 90 day tracer
+  Src_Horiz: all
+e90_n:
+  << : *e90properties
+  FullName: Constant burden Northern Hemisphere 90 day tracer
+  Src_Horiz: lat_zone
+  Src_Lats: [ 40.0, 91.0]
+e90_s:
+  << : *e90properties
+  FullName: Constant burden Southern Hemisphere 90 day tracer
+  Src_Horiz: lat_zone
+  Src_Lats: [ -91.0, -40.0 ]
 EOH:
   DD_F0: 0.0
   DD_Hstar: 1.9e+2
@@ -1230,11 +1344,6 @@ FURA:
   Is_WetDep: true
   MW_g: 68.07
   WD_RetFactor: 2.0e-2
-GlobEmis90dayTracer:
-  FullName: Globally_emitted_tracer_with_90day_lifetime_and_100ppbv_maintained_mixing_ratio
-  Is_Advected: true
-  Is_Gas: true
-  MW_g: 1.0
 GLYC:
   DD_F0: 1.0
   DD_Hstar: 4.1e+4
@@ -3283,6 +3392,28 @@ NAP:
   Is_Advected: true
   Is_Gas: true
   MW_g: 128.18
+nh_PROP: &nhproperties
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: efolding
+  Snk_Vert: all
+  Src_Add: false
+  Src_Mode: constant
+  Src_Horiz: lat_zone
+  Src_Lats: [30.0, 50.0]
+  Src_Units: ppbv
+  Src_Value: 100
+  Src_Vert: all
+nh_5:
+  << : *nhproperties
+  FullName: Northern Hemisphere 5 day tracer
+  Snk_Period: 5
+nh_50:
+  << : *nhproperties
+  FullName: Northern Hemisphere 50 day tracer
+  Snk_Period: 50
 NH3:
   DD_DvzAerSnow: 0.03
   DD_DvzMinVal: [0.2, 0.3]
@@ -3319,11 +3450,6 @@ NH4:
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
   WD_RainoutEff_Luo: [0.4, 0.0, 1.0]
-NHEmis90dayTracer:
-  FullName: Northern_hemisphere_emitted_tracer_with_90day_lifetime_and_100ppbv_maintained_mi
-  Is_Advected: true
-  Is_Gas: true
-  MW_g: 1.0
 NiF1:
   << : *DST1properties
   Formula: Ni
@@ -3654,10 +3780,14 @@ PAN:
   MW_g: 121.06
   WD_RetFactor: 2.0e-2
 PassiveTracer:
+  Background_VV: 1.0e-7
   FullName: Passive tracer for mass conservation evaluation
   Is_Advected: true
   Is_Gas: true
+  Is_Tracer: true
   MW_g: 1.0
+  Snk_Mode: none
+  Src_Mode: none
 Pb210_PROP: &Pbproperties
   DD_DvzAerSnow: 0.03
   DD_F0: 0.0
@@ -3667,8 +3797,18 @@ Pb210_PROP: &Pbproperties
   Is_Aerosol: true
   Is_DryDep: true
   Is_RadioNuclide: true
+  Is_Tracer: true
   Is_WetDep: true
   MW_g: 210.0
+# Comment out tracer-specific code for now and use RnPbBe_mod.F90
+#  Snk_Horiz: all
+#  Snk_Mode: efolding
+#  Snk_Period: 11742.8
+#  Snk_Vert: all
+#  Src_Add: true
+#  Src_Mode: HEMCO
+#  Src_Mode: decay_of_another_species
+#  Src_Species: Rn222
   WD_AerScavEff: 1.0
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [1.0, 0.0, 1.0]
@@ -3676,9 +3816,11 @@ Pb210_PROP: &Pbproperties
 Pb210:
   << : *Pbproperties
   FullName: Lead-210 isotope
-Pb210Strat:
+# Src_Vert: all
+Pb210s:
   << : *Pbproperties
-  FullName: Lead-210 isotope in stratosphere
+  FullName: Lead-210 isotope stratospheric-source tracer
+# Src_Vert: stratosphere
 PbF1:
   << : *DST1properties
   Formula: Pb
@@ -4244,7 +4386,17 @@ Rn222:
   Is_Advected: true
   Is_Aerosol: true
   Is_RadioNuclide: true
+  Is_Tracer: true
   MW_g: 222.0
+# Comment out tracer-specific code for now and use RnPbBe_mod.F90
+#  Snk_Horiz: all
+#  Snk_Mode: efolding
+#  Snk_Period: 5.5
+#  Snk_Vert: all
+#  Src_Add: true
+#  Src_Mode: HEMCO
+#  Src_Mode: decay_of_another_species
+#  Src_Species: Rn222
 ROH:
   Formula: C3H7OH
   FullName: '> C2 alcohols'
@@ -4301,17 +4453,17 @@ SALCCL:
   Is_HygroGrowth: false
   MW_g: 35.45
   WD_CoarseAer: true
-SF6Tracer:
+SF6:
+  Background_VV: 1.0e-20
   Formula: SF6
-  FullName: Sulfur_hexafluoride
+  FullName: Sulfur hexafluoride
   Is_Advected: true
   Is_Gas: true
+  Is_Tracer: true
   MW_g: 146.06
-SHEmis90dayTracer:
-  FullName: Southern_hemisphere_emitted_tracer_with_90day_lifetime_and_100ppbv_maintained_mi
-  Is_Advected: true
-  Is_Gas: true
-  MW_g: 1.0
+  Snk_Mode: none
+  Src_Add: true
+  Src_Mode: HEMCO
 SiF1:
   << : *DST1properties
   Fullname: Silicon on dust, Reff = 0.7 microns
@@ -4458,6 +4610,35 @@ SOAS:
   WD_KcScaleFac: [1.0, 0.5, 1.0]
   WD_RainoutEff: [0.8, 0.0, 0.8]
   WD_RainoutEff_Luo: [0.4, 0.0, 0.8]
+st80_25:
+  FullName: Stratosphere source 25 day tracer
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Snk_Horiz: all
+  Snk_Mode: efolding
+  Snk_Period: 25
+  Snk_Vert: troposphere
+  Src_Add: false
+  Src_Horiz: all
+  Src_Mode: constant
+  Src_Pressures: [0, 80]
+  Src_Units: ppbv
+  Src_Value: 200
+  Src_Vert: pressures
+stOX:
+  FullName: Tracer with O3 values in stratosphere and O3 loss applied in troposphere
+  Is_Advected: true
+  Is_Gas: true
+  Is_Tracer: true
+  Loss_Species: O3
+  Snk_Horiz: all
+  Snk_Mode: chemical_loss
+  Snk_Vert: troposphere
+  Src_Add: false
+  Src_Horiz: all
+  Src_Mode: model_field
+  Src_Vert: stratosphere
 TiF1:
   << : *DST1properties
   Formula: Ti


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

In GEOS-Chem 14.2.0, several TransportTracer species were renamed for consistency with GMAO's tracer gridded component (TR_GridComp). Here the species names are fixed and the `PassiveTracers` benchmark category has been renamed to `TransportTracers`.

### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/pull/1816
- https://github.com/geoschem/HEMCO/pull/214

