### PR TITLE
Remove gcpy_test YAML key from benchmark config files

### DIFF
--- a/benchmark/1mo_benchmark.yml
+++ b/benchmark/1mo_benchmark.yml
@@ -76,7 +76,6 @@ data:
 #   
 options:
   bmk_type: FullChemBenchmark
-  gcpy_test: True # Specify if this is a gcpy test validation run
   comparisons:
     gcc_vs_gcc: 
       run: True # True to run this comparison

--- a/benchmark/1yr_ch4_benchmark.yml
+++ b/benchmark/1yr_ch4_benchmark.yml
@@ -76,7 +76,6 @@ data:
 # 
 options:
   bmk_type: CH4Benchmark
-  gcpy_test: False # Specify if this is a gcpy test validation run
   comparisons:
     gcc_vs_gcc: 
       run: True # True to run this comparison

--- a/benchmark/1yr_fullchem_benchmark.yml
+++ b/benchmark/1yr_fullchem_benchmark.yml
@@ -76,7 +76,6 @@ data:
 # 
 options:
   bmk_type: FullChemBenchmark
-  gcpy_test: True # Specify if this is a gcpy test validation run
   comparisons:
     gcc_vs_gcc: 
       run: True # True to run this comparison

--- a/benchmark/1yr_tt_benchmark.yml
+++ b/benchmark/1yr_tt_benchmark.yml
@@ -76,7 +76,6 @@ data:
 #
 options:
   bmk_type: TransportTracersBenchmark
-  gcpy_test: True
   comparisons:
     gcc_vs_gcc:
       run: True

--- a/benchmark/cloud/template.1hr_benchmark.yml
+++ b/benchmark/cloud/template.1hr_benchmark.yml
@@ -76,7 +76,6 @@ data:
 #
 options:
   bmk_type: FullChemBenchmark
-  gcpy_test: False # Specify if this is a gcpy test validation run
   comparisons:
     gcc_vs_gcc:
       run: False

--- a/benchmark/cloud/template.1mo_benchmark.yml
+++ b/benchmark/cloud/template.1mo_benchmark.yml
@@ -76,7 +76,6 @@ data:
 #
 options:
   bmk_type: FullChemBenchmark
-  gcpy_test: False
   comparisons:
     gcc_vs_gcc:
       run: False


### PR DESCRIPTION
This PR removes several `gcpy_test: False` tags from the various benchmark YAML configuration files.  This should have been done in PR #222 but was not.