### PR TITLE
Shorten the filename of the benchmark operations budget table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The GitHub PR template is now named `./github/PULL_REQUEST_TEMPLATE.md`
 - Now specify package `requests-2.31.0` in `environment.py` (fixes a security issue)
 - Updated badge links in `README.md`
+- Construct ops budget table filename without using the `label` argument
 
 ### Removed
 - Removed `gchp_is_pre_13_1` arguments & code from benchmarking routines

--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -4840,10 +4840,7 @@ def make_benchmark_operations_budget(
     util.make_directory(dst, overwrite)
 
     # Print budgets to file
-    if label is not None:
-        filename = f"{dst}/Budgets_After_Operations_{label}.txt"
-    else:
-        filename = f"{dst}/Budgets_After_Operations.txt".format(dst)
+    filename = f"{dst}/Budgets_After_Operations.txt"
     with open(filename, "w+") as f:
         print("#" * 78, file=f)
         if label is not None and benchmark_type is not None:


### PR DESCRIPTION
This is the companion PR to issue #218.  In `run_benchmark.py` we now pass `label=None` to the routine `make_benchmark_operations_budget` so that the output file will be simply `Budgets_After_Operations.txt`, without appending datetime strings.

No further action needs to be taken for the 1-year benchmark scripts, as these already use shorter labels.

Closes #218 