### PR TITLE
Add lumped furans to emission_species.yml and benchmark_categories.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `benchmark/modules/benchmark_models_vs_obs.py` script
 - Added `benchmark/modules/GC_72_vertical_levels.csv` file
 - Added `multi_index_lat` keyword to `reshape_MAPL_CS` function in `gcpy/util.py`
+- Added FURA to `emission_species.yml` and `benchmark_categories.yml`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`

--- a/gcpy/benchmark_categories.yml
+++ b/gcpy/benchmark_categories.yml
@@ -197,6 +197,7 @@ FullChemBenchmark:
     Nitrates:
       - ISOPN
     Other:
+      - FURA
       - GLYC
       - GLYX
       - HCOOH

--- a/gcpy/emission_species.yml
+++ b/gcpy/emission_species.yml
@@ -20,6 +20,7 @@ FullChemBenchmark:
   DST4: Tg
   EOH: Tg
   ETNO3: Tg
+  FURA: Tg
   GLYC: Tg
   GLYX: Tg
   HAC: Tg


### PR DESCRIPTION
The lumped furan species (FURA) was added in GEOS-Chem 14.2.0.