### PR TITLE
Arrange models vs. observations plots from north to south by site latitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated species_database.yml for consistency with GEOS-Chem 14.2.0
 - Renamed TransportTracers species in `benchmark_categories.yml` and in documentation
 - YAML files in `benchmark/` have been moved to `benchmark/config`
+- Models vs. O3 obs plots are now arranged by site latitude from north to south
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`

--- a/benchmark/modules/benchmark_models_vs_obs.py
+++ b/benchmark/modules/benchmark_models_vs_obs.py
@@ -732,7 +732,7 @@ def plot_one_page(
         msg = "The 'obs_dataframe' argument is not of type pandas.DataFrame!"
         raise TypeError(msg)
     if not isinstance(obs_site_coords, dict):
-        msg = "The 'obs_site_coords' argument is not of type pandas.DataFrame!"
+        msg = "The 'obs_site_coords' argument is not of type dict!"
         raise TypeError(msg)
     if not isinstance(ref_dataarray, xr.DataArray):
         msg = "The 'ref_dataset' argument is not of type xarray.DataArray!"
@@ -878,12 +878,21 @@ def plot_models_vs_obs(
     cols_per_page = 3
     plots_per_page = rows_per_page * cols_per_page
 
-    # List of observation sites to plot
-    obs_site_names = list(obs_dataframe.columns)
-
     # Open the plot as a PDF document
     pdf_file = f"{dst}/models_vs_obs.surface.{varname.split('_')[1]}.pdf"
     pdf = PdfPages(pdf_file)
+
+    # Sort station sites N to S latitude order according to:
+    # https://www.geeksforgeeks.org/python-sort-nested-dictionary-by-key/
+    # NOTE: obs_site_names will be a MultiIndex list (a list of tuples)
+    obs_site_names = sorted(
+        obs_site_coords.items(),
+        key = lambda x: x[1]['lat'],
+        reverse=True
+    )
+
+    # Convert obs_site_names from a MultiIndex list to a regular list
+    obs_site_names = [list(tpl)[0] for tpl in obs_site_names]
 
     # Loop over the number of obs sites that fit on a page
     for start in range(0, len(obs_site_names), plots_per_page):


### PR DESCRIPTION
@mje1398 requested that we sort the models vs. observation benchmark plots from N to S by site latitude.  We have now added this capability into GCPy (specifically, in the `benchmark/modules/benchmark_models_vs_obs.py` script.

Plots now look similar to this:
![2023_07_17_17_32_32_Greenshot](https://github.com/geoschem/gcpy/assets/5880296/ec72e077-de26-46a5-bb13-21aefe352baf)
