### PR TITLE
Fix formatting of mass & emission tables; add mass table option to 1-year TransportTracers benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`
 - Fixed bug in transport tracer benchmark mass conservation table file write
+- Routine `create_display _name` now splits on only the first `_` in species & diag names
 
 ### Removed
 - Removed `gchp_is_pre_13_1` arguments & code from benchmarking routines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Models vs. O3 obs plots are now arranged by site latitude from north to south
 - Routine `print_totals` now prints small and/or large numbers in scientific notation
 - Truncate names in benchmark & emissions tables to improve readability
+- Add TransportTracers species names to `gcpy/emissions_*.yml` files
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `benchmark/modules/GC_72_vertical_levels.csv` file
 - Added `multi_index_lat` keyword to `reshape_MAPL_CS` function in `gcpy/util.py`
 - Added FURA to `emission_species.yml` and `benchmark_categories.yml`
+- Added new routine `format_number_for_table` in `util.py`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`
@@ -31,6 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed TransportTracers species in `benchmark_categories.yml` and in documentation
 - YAML files in `benchmark/` have been moved to `benchmark/config`
 - Models vs. O3 obs plots are now arranged by site latitude from north to south
+- Routine `print_totals` now prints small and/or large numbers in scientific notation
+- Truncate names in benchmark & emissions tables to improve readability
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`

--- a/benchmark/config/1yr_tt_benchmark.yml
+++ b/benchmark/config/1yr_tt_benchmark.yml
@@ -42,7 +42,7 @@ data:
       version: GCC_ref
       dir: GCC_ref
       outputs_subdir: OutputDir
-      restarts_subdir: restarts
+      restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
     gchp:
@@ -59,7 +59,7 @@ data:
       version: GCC_dev
       dir: GCC_dev
       outputs_subdir: OutputDir
-      restarts_subdir: restarts
+      restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
     gchp:
@@ -98,5 +98,6 @@ options:
     plot_wetdep: True
     rnpbbe_budget: True
     operations_budget: False
+    mass_table: True
     ste_table: True
     cons_table: True

--- a/gcpy/emission_inventories.yml
+++ b/gcpy/emission_inventories.yml
@@ -29,3 +29,5 @@ CH4Benchmark:
   GEPA: Tg
   Scarpelli_Canada: Tg
   Scarpelli_Mexico: Tg
+TransportTracersBenchmark:
+  CEDS: Tg

--- a/gcpy/emission_species.yml
+++ b/gcpy/emission_species.yml
@@ -53,3 +53,22 @@ FullChemBenchmark:
   pFe: Tg
 CH4Benchmark:
   CH4: Tg
+TransportTracersBenchmark:
+#  Rn222: kg
+#  Pb210: kg
+#  Pb210s: kg
+  Be7: kg
+  Be7s: kg
+  Be10: kg
+  Be10s: kg
+  CH3I: Tg
+#  CO_25: Tg
+#  CO_50: Tg
+#  e90: Tg
+#  e90_n: Tg
+#  e90_s: Tg
+#  nh_5: Tg
+#  nh_50: Tg
+  SF6:  Tg
+#  st80_25: Tg
+#  stOX: Tg

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -158,6 +158,51 @@ def create_display_name(
     return display_name
 
 
+def format_number_for_table(
+        number,
+        max_thresh=1.0e8,
+        min_thresh=1.0e-6,
+        f_fmt="18.6f",
+        e_fmt="18.8e"
+):
+    """
+    Returns a format string for use in the "print_totals" routine.
+    If the number is greater than a maximum threshold or smaller
+    than a minimum threshold, then use scientific notation format.
+    Otherwise use floating-piont format.
+
+    Special case: do not convert 0.0 to exponential notation.
+
+    Args:
+    -----
+    number : float
+        Number to be printed
+
+    max_thresh, min_thresh: float
+        If |number| > max_thresh, use scientific notation.
+        If |number| < min_thresh, use scientific notation
+
+    f_fmt, e_fmt : str
+        The default floating point string and default scientific
+        notation string.
+        Default values: 18.6f, 18.6e
+
+    Returns:
+    --------
+    fmt_str : str
+        Formatted string that can be inserted into the print
+        statement in print_totals.
+    """
+    abs_number = np.abs(number)
+
+    if not (abs_number > 1e-60):
+        return f"{number:{f_fmt}}"
+
+    if abs_number > max_thresh or abs_number < min_thresh:
+        return f"{number:{e_fmt}}"
+    return f"{number:{f_fmt}}"
+
+
 def print_totals(
         ref,
         dev,
@@ -288,7 +333,24 @@ def print_totals(
     # ==================================================================
     # Write output to file and return
     # ==================================================================
-    print(f"{display_name.ljust(19)}: {total_ref:18.6f}  {total_dev:18.6f}  {diff:12.6f}  {pctdiff:8.3f}  {diff_str}", file=f)
+    ref_fmt = format_number_for_table(total_ref)
+    dev_fmt = format_number_for_table(total_dev)
+    diff_fmt = format_number_for_table(
+        diff,
+        max_thresh=1.0e4,
+        min_thresh=1.0e-4,
+        f_fmt="12.3f",
+        e_fmt="12.4e"
+    )
+    pctdiff_fmt = format_number_for_table(
+        pctdiff,
+        max_thresh=1.0e3,
+        min_thresh=1.0e-3,
+        f_fmt="8.3f",
+        e_fmt="8.1e"
+    )
+
+    print(f"{display_name[0:19].ljust(19)}: {ref_fmt}  {dev_fmt}  {diff_fmt}  {pctdiff_fmt}  {diff_str}", file=f)
 
     return diff_list
 

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -141,8 +141,11 @@ def create_display_name(
     # Initialize
     display_name = diagnostic_name
 
+    # For restart files, just split at the first underscore and return
+    # the text followiong the underscore.  This will preserve certain
+    # species names, such as the TransportTracers species CO_25, etc.
     if "SpeciesRst" in display_name:
-        display_name = display_name.split("_")[1]
+        return display_name.split("_", 1)[1]
 
     # Special handling for Inventory totals
     if "INV" in display_name.upper():
@@ -152,8 +155,8 @@ def create_display_name(
     for v in ["Emis", "EMIS", "emis", "Inv", "INV", "inv"]:
         display_name = display_name.replace(v, "")
 
-    # Replace underscores
-    display_name = display_name.replace("_", " ")
+    # Replace only the first underscore with a space
+    display_name = display_name.replace("_", " ", 1)
 
     return display_name
 
@@ -261,12 +264,11 @@ def print_totals(
     # ==================================================================
     # Get the diagnostic name and units
     # ==================================================================
+    diagnostic_name = dev.name
     if dev_is_all_nan:
         diagnostic_name = ref.name
-    else:
-        diagnostic_name = dev.name
 
-    # Create the display name by editing the diagnostic name
+    # Create the display name for the table
     display_name = create_display_name(diagnostic_name)
 
     # Get the species name from the display name


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html)

### Describe the update

This fixes the problem in the mass table output described by @msulprizio in #237.  This was most apparent in the TransportTracers benchmarks, where underflow was causing several entries to show up as zero even though they were very small numbers.

This PR adds the following features:
- Add routine `format_number_for_table`, which generates a format string for numbers used in mass table and emission table output.  If the number is larger or smaller than supplied thresholds, it will be printed in scientific notation instead of floating-point notation.
- Species and diagnostic names mass tables and emissions tables are truncated to prevent columns from not being aligned.
- When formatting species and diagnostic names for display, strings are split only to the first `_` character.  This will ensure that certain species names (such as TransportTracers species `CO_25`) will be printed properly.
- Added the mass_table option to `gcpy/benchmark/config/1yr_tt_benchmark.yml` configuration file.
- Added python code to print mass tables in `gcpy/benchmark/modules/run_1yr_tt_benchmark.py`.

### Expected changes

Mass table output with very small & very large numbers now looks like this (e.g. the TransportTracers mass table):
```console
#########################################################################################
### Global mass (Gg) at end of simulation (Trop + Strat)                              ###
###                                                                                   ###
### Ref = GCC_ref                                                                     ###
### Dev = GCC_dev                                                                     ###
###                                                                                   ###
### Dev and Ref show 8 differences                                                    ###
#########################################################################################
                                    Ref                 Dev     Dev - Ref    % diff diffs
Be10               :     2.66473250e-07      2.66473250e-07         0.000     0.000  
Be10s              :     2.54115760e-07      2.54115760e-07         0.000     0.000  
Be7                :     2.00170962e-08      2.00170962e-08   -1.3764e-21  -6.9e-12   * 
Be7s               :     1.68048853e-08      1.68048853e-08         0.000     0.000  
CH3I               :     3.68623921e-07      1.50224460e-09   -3.6712e-07   -99.592   * 
CLOCK              :     6.42508074e+19                 nan           nan       nan  
COUniformEmis25dayT:     1.64866620e+08                 nan           nan       nan  
CO_25              :       40622.143731          119.484126   -4.0503e+04   -99.706   * 
CO_50              :       78936.667877          119.903490   -7.8817e+04   -99.848   * 
PassiveTracer      :       17656.169678        17656.169678         0.000     0.000  
Pb210              :     2.96838610e-07      2.96838610e-07         0.000     0.000  
Pb210s             :     5.08194860e-09      5.08194860e-09   -1.0588e-22  -2.1e-12   * 
Rn222              :     2.06571294e-07      2.06571294e-07         0.000     0.000  
SF6                :         261.488003          261.488003         0.000     0.000  
aoa                :                nan      3.25828342e+12           nan       nan  
aoa_bl             :                nan      3.25917692e+12           nan       nan  
aoa_nh             :                nan      3.25917692e+12           nan       nan  
e90                :       14223.136187        13512.936825      -710.199    -4.993   * 
e90_n              :       14167.130101        13512.936798      -654.193    -4.618   * 
e90_s              :       14288.237337        13512.936798      -775.301    -5.426   * 
```

### Related Github Issues:

- Closes #237

