### PR TITLE
Add fixes for 14.2.0 benchmarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `multi_index_lat` keyword to `reshape_MAPL_CS` function in `gcpy/util.py`
 - Added FURA to `emission_species.yml` and `benchmark_categories.yml`
 - Added new routine `format_number_for_table` in `util.py`
+- Added BrSALA and BrSALC to `emission_species.yml`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`

--- a/gcpy/emission_species.yml
+++ b/gcpy/emission_species.yml
@@ -5,6 +5,8 @@ FullChemBenchmark:
   BCPI: Tg
   BCPO: Tg
   BENZ: Tg
+  BrSALA: Tg
+  BrSALC: Tg
   C2H2: Tg
   C2H4: Tg
   C2H6: Tg

--- a/gcpy/species_database.yml
+++ b/gcpy/species_database.yml
@@ -3377,6 +3377,7 @@ nh_PROP: &nhproperties
   Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
+  MW_g: 1.0
   Snk_Horiz: all
   Snk_Mode: efolding
   Snk_Vert: all
@@ -4596,6 +4597,7 @@ st80_25:
   Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
+  MW_g: 1.0
   Snk_Horiz: all
   Snk_Mode: efolding
   Snk_Period: 25
@@ -4607,19 +4609,6 @@ st80_25:
   Src_Units: ppbv
   Src_Value: 200
   Src_Vert: pressures
-stOX:
-  FullName: Tracer with O3 values in stratosphere and O3 loss applied in troposphere
-  Is_Advected: true
-  Is_Gas: true
-  Is_Tracer: true
-  Loss_Species: O3
-  Snk_Horiz: all
-  Snk_Mode: chemical_loss
-  Snk_Vert: troposphere
-  Src_Add: false
-  Src_Horiz: all
-  Src_Mode: model_field
-  Src_Vert: stratosphere
 TiF1:
   << : *DST1properties
   Formula: Ti

--- a/gcpy/species_database.yml
+++ b/gcpy/species_database.yml
@@ -140,6 +140,7 @@ aoa_PROP: &aoaproperties
   Is_Advected: true
   Is_Gas: true
   Is_Tracer: true
+  MW_g: 1.0
   Snk_Mode: constant
   Snk_Value: 0
   Src_Add: true


### PR DESCRIPTION
In this PR we add minor fixes for 14.2.0 benchmarking, including:

1. Defining MW_g for several transport tracer species
2. Add BrSALA and BrSALC to emission_species.yml