### PR TITLE
Now use a consistent width for columns in emissions tables and mass table output

### DIFF
--- a/gcpy/benchmark.py
+++ b/gcpy/benchmark.py
@@ -20,6 +20,7 @@ from gcpy.regrid import create_regridders
 from gcpy.grid import get_troposphere_mask
 from gcpy.units import convert_units
 import gcpy.constants as gcon
+from gcpy.constants import TABLE_WIDTH, COL_WIDTH
 
 # Save warnings format to undo overwriting built into PyPDF2
 warning_format = warnings.showwarning
@@ -28,9 +29,9 @@ warning_format = warnings.showwarning
 np.seterr(divide="ignore", invalid="ignore")
 
 # YAML files
-aod_spc = "aod_species.yml"
-emission_spc = "emission_species.yml"
-emission_inv = "emission_inventories.yml"
+AOD_SPC = "aod_species.yml"
+EMISSION_SPC = "emission_species.yml"
+EMISSION_INV = "emission_inventories.yml"
 
 
 def create_total_emissions_table(
@@ -122,12 +123,8 @@ def create_total_emissions_table(
     # ==================================================================
     # Initialization
     # ==================================================================
-
-    # Make sure refdata and devdata are both xarray Dataset objects
-    if not isinstance(refdata, xr.Dataset):
-        raise TypeError("The refdata argument must be an xarray Dataset!")
-    if not isinstance(devdata, xr.Dataset):
-        raise TypeError("The devdata argument must be an xarray Dataset!")
+    util.verify_variable_type(refdata, xr.Dataset)
+    util.verify_variable_type(devdata, xr.Dataset)
 
     # Get ref area [m2]
     if "AREA" in refdata.data_vars.keys():
@@ -155,7 +152,7 @@ def create_total_emissions_table(
     # this benchmark.py file is found.
     properties = util.read_config_file(
         os.path.join(
-            spcdb_dir, 
+            spcdb_dir,
             "species_database.yml"
         ),
         quiet=True
@@ -228,7 +225,7 @@ def create_total_emissions_table(
         # Push the total variable to the last list element
         # so that it will be printed last of all
         if len(vartot) == 1:
-            varnames.append(varnames.pop(varnames.index(vartot[0])))        
+            varnames.append(varnames.pop(varnames.index(vartot[0])))
 
         # Title strings
         if "Inv" in template:
@@ -244,12 +241,12 @@ def create_total_emissions_table(
         title3 = f"### Dev = {devstr}"
 
         # Print header to file
-        print("#" * 89, file=f)
-        print(f"{title1 : <86}{'###'}", file=f)
-        print(f"{title2 : <86}{'###'}", file=f)
-        print(f"{title3 : <86}{'###'}", file=f)
-        print("#" * 89, file=f)
-        print(f"{'' : <19}{'Ref' : >20}{'Dev' : >20}{'Dev - Ref' : >14}{'% diff' : >10} {'diffs'}", file=f)
+        print("#" * TABLE_WIDTH, file=f)
+        print(f"{title1 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+        print(f"{title2 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+        print(f"{title3 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+        print("#" * TABLE_WIDTH, file=f)
+        print(f"{'' : <{COL_WIDTH-1}}{'Ref' : >{COL_WIDTH}}{'Dev' : >{COL_WIDTH}}{'Dev - Ref' : >{COL_WIDTH}}{'% diff' : >{COL_WIDTH}} {'diffs'}", file=f)
 
         # =============================================================
         # Loop over all emissions variables corresponding to this
@@ -361,7 +358,7 @@ def create_total_emissions_table(
             refstr,
             devstr,
             diff_list),
-        width=90
+        width=TABLE_WIDTH
     )
 
 def create_global_mass_table(
@@ -431,12 +428,8 @@ def create_global_mass_table(
     # ==================================================================
     # Initialization
     # ==================================================================
-
-    # Make sure refdata and devdata are xarray Dataset objects
-    if not isinstance(refdata, xr.Dataset):
-        raise TypeError("The refdata argument must be an xarray Dataset!")
-    if not isinstance(devdata, xr.Dataset):
-        raise TypeError("The devdata argument must be an xarray Dataset!")
+    util.verify_variable_type(refdata, xr.Dataset)
+    util.verify_variable_type(devdata, xr.Dataset)
 
     # Make sure required arguments are passed
     if varlist is None:
@@ -480,17 +473,17 @@ def create_global_mass_table(
     placeholder = "@%% insert diff status here %%@"
 
     # Print header to file
-    print("#" * 89, file=f)
-    print(f"{title1 : <86}{'###'}", file=f)
-    print(f"{'###'  : <86}{'###'}", file=f)
-    print(f"{title2 : <86}{'###'}", file=f)
-    print(f"{title3 : <86}{'###'}", file=f)
-    print(f"{'###'  : <86}{'###'}", file=f)
+    print("#" * TABLE_WIDTH, file=f)
+    print(f"{title1 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{'###'  : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title2 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title3 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{'###'  : <{TABLE_WIDTH-3}}{'###'}", file=f)
     print(f"{placeholder}", file=f)
-    print("#" * 89, file=f)
+    print("#" * TABLE_WIDTH, file=f)
 
     # Column headers
-    print(f"{'' : <19}{'Ref' : >20}{'Dev' : >20}{'Dev - Ref' : >14}{'% diff' : >10} {'diffs'}", file=f)
+    print(f"{'' : <{COL_WIDTH-1}}{'Ref' : >{COL_WIDTH}}{'Dev' : >{COL_WIDTH}}{'Dev - Ref' : >{COL_WIDTH}}{'% diff' : >{COL_WIDTH}} {'diffs'}", file=f)
 
     # ==================================================================
     # Print global masses for all species
@@ -592,7 +585,7 @@ def create_global_mass_table(
             diff_list,
             fancy_format=True
         ),
-        width=100  # Force it not to wrap
+        width=TABLE_WIDTH
     )
 
 
@@ -675,16 +668,10 @@ def create_mass_accumulation_table(
     # ==================================================================
     # Initialization
     # ==================================================================
-
-    # Make sure refdata and devdata are xarray Dataset objects
-    if not isinstance(refdatastart, xr.Dataset):
-        raise TypeError("The refdatastart argument must be an xarray Dataset!")
-    if not isinstance(refdataend, xr.Dataset):
-        raise TypeError("The refdataend argument must be an xarray Dataset!")
-    if not isinstance(devdatastart, xr.Dataset):
-        raise TypeError("The devdatastart argument must be an xarray Dataset!")
-    if not isinstance(devdataend, xr.Dataset):
-        raise TypeError("The devdataend argument must be an xarray Dataset!")
+    util.verify_variable_type(refdatastart, xr.Dataset)
+    util.verify_variable_type(refdataend, xr.Dataset)
+    util.verify_variable_type(devdatastart, xr.Dataset)
+    util.verify_variable_type(devdataend, xr.Dataset)
 
     # Make sure required arguments are passed
     if varlist is None:
@@ -731,22 +718,22 @@ def create_mass_accumulation_table(
     placeholder = "@%% insert diff status here %%@"
 
     # Print header to file
-    print("#" * 89, file=f)
-    print(f"{title1 : <86}{'###'}", file=f)
-    print(f"{'###'  : <86}{'###'}", file=f)
-    print(f"{title2 : <86}{'###'}", file=f)
-    print(f"{'###'  : <86}{'###'}", file=f)
-    print(f"{title3 : <86}{'###'}", file=f)
-    print(f"{title4 : <86}{'###'}", file=f)
-    print(f"{'###'  : <86}{'###'}", file=f)
-    print(f"{title5 : <86}{'###'}", file=f)
-    print(f"{title6 : <86}{'###'}", file=f)
-    print(f"{'###'  : <86}{'###'}", file=f)
+    print("#" * TABLE_WIDTH, file=f)
+    print(f"{title1 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{'###'  : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title2 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{'###'  : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title3 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title4 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{'###'  : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title5 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{title6 : <{TABLE_WIDTH-3}}{'###'}", file=f)
+    print(f"{'###'  : <{TABLE_WIDTH-3}}{'###'}", file=f)
     print(f"{placeholder}", file=f)
-    print("#" * 89, file=f)
+    print("#" * TABLE_WIDTH, file=f)
 
     # Column headers
-    print(f"{'' : <19}{'Ref' : >20}{'Dev' : >20}{'Dev - Ref' : >14}{'% diff' : >10} {'diffs'}", file=f)
+    print(f"{'' : <{COL_WIDTH-1}}{'Ref' : >{COL_WIDTH}}{'Dev' : >{COL_WIDTH}}{'Dev - Ref' : >{COL_WIDTH}}{'% diff' : >{COL_WIDTH}} {'diffs'}", file=f)
 
     # ==================================================================
     # Print global masses for all species
@@ -880,7 +867,7 @@ def create_mass_accumulation_table(
             diff_list,
             fancy_format=True
         ),
-        width=100  # Force it not to wrap
+        width=TABLE_WIDTH
     )
 
 
@@ -1083,7 +1070,7 @@ def make_benchmark_conc_plots(
     diff_of_diffs = False
     if second_ref is not None and second_dev is not None:
         diff_of_diffs = True
-   
+
 
     # Open second datasets if passed as arguments (used for diff of diffs)
     # Regrid to same horz grid resolution if two refs or two devs do not match.
@@ -2121,7 +2108,7 @@ def make_benchmark_emis_tables(
     spc_dict = util.read_config_file(
         os.path.join(
             os.path.dirname(__file__),
-            emission_spc
+            EMISSION_SPC
         ),
         quiet=True
     )
@@ -2129,7 +2116,7 @@ def make_benchmark_emis_tables(
     inv_dict = util.read_config_file(
         os.path.join(
             os.path.dirname(__file__),
-            emission_inv
+            EMISSION_INV
         ),
         quiet=True
     )
@@ -2756,7 +2743,7 @@ def make_benchmark_aod_plots(
     newvars = util.read_config_file(
         os.path.join(
             os.path.dirname(__file__),
-            aod_spc
+            AOD_SPC
         ),
         quiet=True
     )
@@ -3163,6 +3150,7 @@ def make_benchmark_mass_tables(
     del refds
     del devds
     gc.collect()
+
 
 def make_benchmark_mass_accumulation_tables(
         ref_start,
@@ -4019,7 +4007,7 @@ def make_benchmark_aerosol_tables(
     # Read the species database
     spcdb = util.read_config_file(
         os.path.join(
-            spcdb_dir, 
+            spcdb_dir,
             "species_database.yml"
         ),
         quiet=True
@@ -4761,7 +4749,7 @@ def make_benchmark_operations_budget(
                 # Get ref and dev mass
 
                 # Get species properties for unit conversion. If none, skip.
-                species_properties = properties.get(spc)                
+                species_properties = properties.get(spc)
                 if species_properties is None:
                     continue
                 else:
@@ -4771,7 +4759,7 @@ def make_benchmark_operations_budget(
 
                 # Specify target units
                 target_units = "Gg"
-                
+
                 # ==============================================================
                 # Convert units of Ref and save to a DataArray
                 # (or skip if Ref contains NaNs everywhere)
@@ -4787,7 +4775,7 @@ def make_benchmark_operations_budget(
                         delta_p=met_and_masks["Ref_Delta_P"],
                         box_height=met_and_masks["Ref_BxHeight"],
                     )
-                
+
                 # ==============================================================
                 # Convert units of Dev and save to a DataArray
                 # (or skip if Dev contains NaNs everywhere)
@@ -5214,7 +5202,7 @@ def create_benchmark_summary_table(
     # Print header to file
     print("#" * 80, file=f)
     print(f"{title1 : <77}{'###'}", file=f)
-    print(f"{'###'  : <77}{'###'}", file=f)   
+    print(f"{'###'  : <77}{'###'}", file=f)
     print(f"{title2 : <77}{'###'}", file=f)
     print(f"{title3 : <77}{'###'}", file=f)
     print("#" * 80, file=f)
@@ -5334,14 +5322,13 @@ def diff_list_to_text(
     diff_text : str
         String with concatenated list values.
     """
-    if not isinstance(diff_list, list):
-        raise ValueError("Argument 'diff_list' must be a list!")
+    util.verify_variable_type(diff_list, list)
 
     # Use "Dev" and "Ref" for inserting into a header
     if fancy_format:
         refstr = "Ref"
         devstr = "Dev"
-        
+
     # Strip out duplicates from diff_list
     # Prepare a message about species differences (or alternate msg)
     diff_list = util.unique_values(diff_list, drop=[None])
@@ -5353,15 +5340,16 @@ def diff_list_to_text(
     else:
         diff_text = f"{devstr} and {refstr} are identical"
 
-    # If we are placing the text in a header,
-    # then trim the length of diff_text to fit.
+    # If we are placing the text in a header, trim the length of diff_text
+    # to fit.  NOTE: TABLE_WIDTH-7 leaves room for the '### ' at the start
+    # of the string and the '###' at the end of the string,
     if fancy_format:
+        diff_text = f"### {diff_text : <{TABLE_WIDTH-7}}{'###'}"
         diff_text = util.wrap_text(
             diff_text,
-            width=83
+            width=TABLE_WIDTH
         )
-        diff_text = f"### {diff_text : <82}{'###'}"
-        
+
     return diff_text.strip()
 
 
@@ -5385,12 +5373,8 @@ def diff_of_diffs_toprow_title(config, model):
     title: str
         The plot title string for the diff-of-diff
     """
-    if not isinstance(config, dict):
-        msg = "The 'config' argument must be of type 'dict`!"
-        raise ValueError(msg)
-    if not isinstance(model, str):
-        msg = "The 'model' argument must be of type 'str'!"
-        raise ValueError(msg)
+    util.verify_variable_type(config, dict)
+    util.verify_variable_type(model, str)
     if not "gcc" in model and not "gchp" in model:
         msg = "The 'model' argument must be either 'gcc' or 'gchp'!"
         raise ValueError(msg)

--- a/gcpy/constants.py
+++ b/gcpy/constants.py
@@ -48,3 +48,11 @@ skip_these_vars = [
     "contacts",
     "cubed_sphere"
 ]
+
+
+# ======================================================================
+# Table and column widths for emissions & mass tables
+# ======================================================================
+TABLE_WIDTH = 105
+COL_WIDTH = 20
+

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -338,8 +338,8 @@ def print_totals(
     # ==================================================================
     ref_fmt = format_number_for_table(total_ref)
     dev_fmt = format_number_for_table(total_dev)
-    diff_fmt = format_number_for_table(total_dev)
-    pctdiff_fmt = format_number_for_table(total_dev)
+    diff_fmt = format_number_for_table(diff)
+    pctdiff_fmt = format_number_for_table(pctdiff)
 
     print(f"{display_name[0:19].ljust(19)}: {ref_fmt}  {dev_fmt}  {diff_fmt}  {pctdiff_fmt}  {diff_str}", file=f)
 

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -11,6 +11,11 @@ from yaml import safe_load as yaml_safe_load
 import numpy as np
 import xarray as xr
 from PyPDF2 import PdfFileWriter, PdfFileReader
+from gcpy.constants import TABLE_WIDTH
+
+# ======================================================================
+# %%%%% METHODS %%%%%
+# ======================================================================
 
 def convert_lon(
         data,
@@ -42,6 +47,7 @@ def convert_lon(
     Returns:
         data, with dimension 'dim' altered according to conversion rule
     """
+    verify_variable_type(data, (xr.DataArray, xr.Dataset))
 
     data_copy = data.copy()
 
@@ -241,14 +247,9 @@ def print_totals(
     # ==================================================================
     # Initialization and error checks
     # ==================================================================
-
-    # Make sure that both Ref and Dev are xarray DataArray objects
-    if not isinstance(ref, xr.DataArray):
-        raise TypeError("The 'ref' argument must be an xarray DataArray!")
-    if not isinstance(dev, xr.DataArray):
-        raise TypeError("The 'dev' argument must be an xarray DataArray!")
-    if not isinstance(diff_list, list):
-        raise TypeError("The 'diff_list' argument must be a list!")
+    verify_variable_type(ref, xr.DataArray)
+    verify_variable_type(dev, xr.DataArray)
+    verify_variable_type(diff_list, list)
 
     # Determine if either Ref or Dev have all NaN values:
     ref_is_all_nan = np.isnan(ref.values).all()
@@ -279,7 +280,7 @@ def print_totals(
 
     # Special handling for totals
     if "_TOTAL" in diagnostic_name.upper():
-        print("-"*90, file=f)
+        print("-" * TABLE_WIDTH, file=f)
 
     # ==================================================================
     # Sum the Ref array (or set to NaN if missing)
@@ -337,20 +338,8 @@ def print_totals(
     # ==================================================================
     ref_fmt = format_number_for_table(total_ref)
     dev_fmt = format_number_for_table(total_dev)
-    diff_fmt = format_number_for_table(
-        diff,
-        max_thresh=1.0e4,
-        min_thresh=1.0e-4,
-        f_fmt="12.3f",
-        e_fmt="12.4e"
-    )
-    pctdiff_fmt = format_number_for_table(
-        pctdiff,
-        max_thresh=1.0e3,
-        min_thresh=1.0e-3,
-        f_fmt="8.3f",
-        e_fmt="8.1e"
-    )
+    diff_fmt = format_number_for_table(total_dev)
+    pctdiff_fmt = format_number_for_table(total_dev)
 
     print(f"{display_name[0:19].ljust(19)}: {ref_fmt}  {dev_fmt}  {diff_fmt}  {pctdiff_fmt}  {diff_str}", file=f)
 
@@ -593,12 +582,8 @@ def add_missing_variables(
     # ==================================================================
     # Initialize
     # ==================================================================
-
-    # Make sure that refdata and devdata are both xarray Dataset objects
-    if not isinstance(refdata, xr.Dataset):
-        raise TypeError("The refdata object must be an xarray Dataset!")
-    if not isinstance(devdata, xr.Dataset):
-        raise TypeError("The refdata object must be an xarray Dataset!")
+    verify_variable_type(refdata, xr.Dataset)
+    verify_variable_type(devdata, xr.Dataset)
 
     # Find common variables as well as variables only in one or the other
     vardict = compare_varnames(refdata, devdata, quiet=True)
@@ -804,9 +789,7 @@ def slice_by_lev_and_time(
             DataArray of data variable sliced according to ilev and itime
     """
     # used in compare_single_level and compare_zonal_mean to get dataset slices
-    if not isinstance(ds, xr.Dataset):
-        msg="ds is not of type xarray.Dataset!"
-        raise TypeError(msg)
+    verify_variable_type(ds, xr.Dataset)
     if not varname in ds.data_vars.keys():
         msg="Could not find 'varname' in ds!"
         raise ValueError(msg)
@@ -881,6 +864,9 @@ def dict_diff(
         result: dict
             Key-by-key difference of dict1 - dict0
     """
+    verify_variable_type(dict0, dict)
+    verify_variable_type(dict1, dict)
+
     result = {}
     for key, _ in dict0.items():
         result[key] = dict1[key] - dict0[key]
@@ -936,6 +922,9 @@ def compare_varnames(
             devonly          List of 2D or 3D variables that are only
                              present in devdata
     """
+    verify_variable_type(refdata, xr.Dataset)
+    verify_variable_type(devdata, xr.Dataset)
+
     refvars = [k for k in refdata.data_vars.keys()]
     devvars = [k for k in devdata.data_vars.keys()]
     commonvars = sorted(list(set(refvars).intersection(set(devvars))))
@@ -1485,12 +1474,8 @@ def divide_dataset_by_dataarray(
     # -----------------------------
     # Check arguments
     # -----------------------------
-    if not isinstance(ds, xr.Dataset):
-        raise TypeError("The ds argument must be of type xarray.Dataset!")
-
-    if not isinstance(dr, xr.DataArray):
-        raise TypeError("The dr argument must be of type xarray.DataArray!")
-
+    verify_variable_type(ds, xr.Dataset)
+    verify_variable_type(dr, xr.DataArray)
     if varlist is None:
         varlist = ds.data_vars.keys()
 
@@ -1545,7 +1530,6 @@ def get_shape_of_data(
             (['time', 'lev', 'lat', 'lon'] for GEOS-Chem "Classic",
              or ['time', 'lev', 'nf', 'Ydim', 'Xdim'] for GCHP.
     """
-
     # Validate the data argument
     if isinstance(data, (xr.Dataset, xr.DataArray)):
         sizelist = data.sizes
@@ -1590,6 +1574,7 @@ def get_area_from_dataset(
         area_m2: xarray DataArray
             The surface area in m2, as found in ds.
     """
+    verify_variable_type(ds, xr.Dataset)
 
     if "Met_AREAM2" in ds.data_vars.keys():
         return ds["Met_AREAM2"]
@@ -1626,6 +1611,7 @@ def get_variables_from_dataset(
     Use this routine if you absolutely need all of the requested
     variables to be returned.  Otherwise
     """
+    verify_variable_type(ds, xr.Dataset)
 
     ds_subset = xr.Dataset()
     for v in varlist:
@@ -1753,6 +1739,7 @@ def check_for_area(
         ds: xarray Dataset
             The modified Dataset object
     """
+    verify_variable_type(ds, xr.Dataset)
 
     found_gcc = gcc_area_name in ds.data_vars.keys()
     found_gchp = gchp_area_name in ds.data_vars.keys()


### PR DESCRIPTION
This is the companion PR to issue #247.  We have modified code the `gcpy/benchmark.py`, `gcpy/util.py`, and `gcpy/constants.py` so that the `Dev - Ref` and `% diff` columns are plotted with the same format as the `Ref` and `Dev` columns.  This should now prevent very small values from rendering as zeroes in the table output.

The new mass table output now looks like this:
```console
#########################################################################################################
### Global mass (Gg) at end of simulation (Trop + Strat)                                              ###
###                                                                                                   ###
### Ref = GCC_ref                                                                                     ###
### Dev = GCC_dev                                                                                     ###
###                                                                                                   ###
### Dev and Ref show 5 differences                                                                    ###
#########################################################################################################
                                    Ref                 Dev           Dev - Ref              % diff diffs
Be10               :     2.66473250e-07      2.66473250e-07            0.000000            0.000000  
Be10s              :     2.54115760e-07      2.54115760e-07            0.000000            0.000000  
Be7                :     2.00170962e-08      2.00170962e-08     -1.37642854e-21     -6.87626481e-12   * 
Be7s               :     1.68048853e-08      1.68048853e-08            0.000000            0.000000  
CH3I               :     3.68623921e-07      3.68623921e-07            0.000000            0.000000  
CLOCK              :     6.42508074e+19                 nan                 nan                 nan  
COUniformEmis25dayT:     1.64866620e+08                 nan                 nan                 nan  
CO_25              :       40622.143731        40622.143731            0.000000            0.000000  
CO_50              :       78936.667877        78936.667877            0.000000            0.000000  
PassiveTracer      :       17656.169678        17656.169678            0.000000            0.000000  
Pb210              :     2.96838610e-07      2.96838610e-07            0.000000            0.000000  
Pb210s             :     5.08194860e-09      5.08194860e-09     -1.05879118e-22     -2.08343545e-12   * 
Rn222              :     2.06571294e-07      2.06571294e-07            0.000000            0.000000  
SF6                :         261.488003          261.488003            0.000000            0.000000  
aoa                :                nan      3.25828342e+12                 nan                 nan  
aoa_bl             :                nan      3.09389831e+12                 nan                 nan  
aoa_nh             :                nan      4.92178131e+12                 nan                 nan  
e90                :       14223.136187        11564.665749        -2658.470438          -18.691169   * 
e90_n              :       14167.130101        11493.947799        -2673.182302          -18.868905   * 
e90_s              :       14288.237337        11570.274678        -2717.962659          -19.022379   * 
stOX               :                nan        58944.808586                 nan                 nan  
```
and the new emissions table output looks like this:
```console
GCC_dev and GCC_ref show 2 differences


#########################################################################################################
### Emissions totals for species Be7 [Tg]                                                             ###
### Ref = GCC_ref                                                                                     ###
### Dev = GCC_dev                                                                                     ###
#########################################################################################################
                                    Ref                 Dev           Dev - Ref              % diff diffs
Be7 Cosmic         :           0.012483            0.012483     -5.20417043e-18     -4.16895274e-14   * 
```
etc.