### PR TITLE
Fixed broken regridding code in file_regrid.py; Updated GCPy regridding documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added coding suggestions made by `pylint` where possible
 - Abstracted and never-nested code from `six_plot` into functions (in `plot.py`)
 - Added `main()` routine to `gcpy/file_regrid.py`; Also added updates suggested by Pylint
-
-### Removed
-- Removed `gchp_is_pre_13_1` arguments & code from benchmarking routines
-- Removed `is_pre_13_1` tags from `*_benchmark.yml` config files
+- Fixed broken regridding code in `gcpy/file_regrid.py`; also refactored for clarity
+- Rewrote `Regridding.rst` page; Confirmed that regridding examples work properly
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`


### PR DESCRIPTION
This PR has introduced several updates into the `gcpy/file_regrid.py` script (see 0bb6acef):

- Fixed broken regridding code (especially lat/lon -> cubed sphere/stretched grid)
- Ensured that all combinations of regridding work
- Refactored code from `if/elif` blocks into separate routines
- Updated PyDoc comments

Also rewrote the `docs/source/Regridding.rst` page (see 2b160b6 and dddf513) to be consistent with the updates in `gcpy/file_regrid.py`.  Also confirmed that all regridding examples with online and offline regridding weights work as advertised.