### PR TITLE
Peg xarray to version 2023.2.0 in the environment.yml file

### DIFF
--- a/docs/environment_files/environment.yml
+++ b/docs/environment_files/environment.yml
@@ -35,7 +35,13 @@ dependencies:
     - scipy                           # Scientific python package
     - sparselt>=0.1.3                 # Regridding earth system model data
     - tabulate                        # Pretty-printing for column data
-    - xarray                          # Read data from netCDF etc files
+    #
+    # NOTE: The most recent xarray (2023.8.0) seems to break backwards
+    # compatibility with the benchmark plotting code.  Peg to 2023.2.0
+    # until we can update GCPy for the most recent xarray.
+    #  -- Bob Yantosca (29 Aug 2023)
+    #
+    - xarray==2023.2.0                # Read data from netCDF etc files
     #
     # NOTE: These packages need to be pegged at specific versions
     # in order to avoid an ImportError.


### PR DESCRIPTION
This PR pegs the xarray version at 2023.2.0 in the environment file `docs/environment_files/environment.yml`.  This is because the most recent version (2023.8.0) seems to have some under-the-hood shenanigans with `dask` that breaks backwards compatibility with the benchmark plotting scripts.

This is a temporary measure intended to give us a little more time to figure out what code modifications are needed so that GCPy can work with the latest xarray.
