### PR TITLE
Rename PassiveTracers to TransportTracers in run_1yr_tt_benchmark.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated badge links in `README.md`
 - Construct ops budget table filename without using the `label` argument
 - Updated species_database.yml for consistency with GEOS-Chem 14.2.0
-- Renamed TransportTracers species in `benchmark_categories.yml` and in documentation
+- Renamed TransportTracers species in `benchmark_categories.yml`, `run_1yr_tt_benchmark.py`, and in documentation
 - YAML files in `benchmark/` have been moved to `benchmark/config`
 - Models vs. O3 obs plots are now arranged by site latitude from north to south
 - Routine `print_totals` now prints small and/or large numbers in scientific notation

--- a/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/benchmark/modules/run_1yr_tt_benchmark.py
@@ -349,7 +349,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             print("\n%%% Creating GCC vs. GCC concentration plots %%%")
 
             # Only plot concentration categories for TransportTracers
-            restrict_cats = ["RnPbBeTracers", "PassiveTracers"]
+            restrict_cats = ["RnPbBeTracers", "TransportTracers"]
 
             # --------------------------------------------------------------
             # GCC vs GCC species concentration plots: Annual mean
@@ -629,7 +629,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             print("\n%%% Creating GCHP vs. GCC concentration plots %%%")
 
             # Only plot concentration categories for TransportTracers
-            restrict_cats = ["RnPbBeTracers", "PassiveTracers"]
+            restrict_cats = ["RnPbBeTracers", "TransportTracers"]
 
             # --------------------------------------------------------------
             # GCHP vs GCC species concentration plots: Annual Mean
@@ -889,7 +889,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             print("\n%%% Creating GCHP vs. GCHP concentration plots %%%")
 
             # Only plot concentration categories for TransportTracers
-            restrict_cats = ["RnPbBeTracers", "PassiveTracers"]
+            restrict_cats = ["RnPbBeTracers", "TransportTracers"]
 
             # --------------------------------------------------------------
             # GCHP vs GCHP species concentration plots: Annual Mean


### PR DESCRIPTION
The benchmark category name was changed from PassiveTracers to TransportTracers in commit 606ef01f. Code also needed to be updated in run_1yr_tt_benchmark.py to include plots for the species in that category.