### PR TITLE
Update plot.py for more recent xarray; also allow dask arrays to be passed to single_panel, six_plot routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added new routine `format_number_for_table` in `util.py`
 - Added BrSALA and BrSALC to `emission_species.yml`
 - Added `ENCODING = "UTF-8"` to `gcpy/constants.py`
+- Added statement `from dask.array import Array as DaskArray` in `gcpy plot.py`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`
@@ -46,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `main()` routine to `gcpy/file_regrid.py`; Also added updates suggested by Pylint
 - Fixed broken regridding code in `gcpy/file_regrid.py`; also refactored for clarity
 - Rewrote `Regridding.rst` page; Confirmed that regridding examples work properly
+- Now allow `plot_val` to be of type `dask.array.Array` in `plot.py` routines `six_plot` and `single_panel`
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`

--- a/docs/environment_files/environment.yml
+++ b/docs/environment_files/environment.yml
@@ -35,13 +35,7 @@ dependencies:
     - scipy                           # Scientific python package
     - sparselt>=0.1.3                 # Regridding earth system model data
     - tabulate                        # Pretty-printing for column data
-    #
-    # NOTE: The most recent xarray (2023.8.0) seems to break backwards
-    # compatibility with the benchmark plotting code.  Peg to 2023.2.0
-    # until we can update GCPy for the most recent xarray.
-    #  -- Bob Yantosca (29 Aug 2023)
-    #
-    - xarray==2023.2.0                # Read data from netCDF etc files
+    - xarray                          # Read data from netCDF etc files
     #
     # NOTE: These packages need to be pegged at specific versions
     # in order to avoid an ImportError.

--- a/gcpy/plot.py
+++ b/gcpy/plot.py
@@ -88,7 +88,7 @@ def six_plot(
         all_nan: bool
             Set this flag to True if the data to be plotted consist
             only of NaNs
-        plot_vals: xarray.DataArray, numpy.ndarray, or dask.array.Array
+        plot_val: xarray.DataArray, numpy.ndarray, or dask.array.Array
             Single data variable GEOS-Chem output to plot
         grid: dict
             Dictionary mapping plot_val to plottable coordinates

--- a/gcpy/plot.py
+++ b/gcpy/plot.py
@@ -88,8 +88,8 @@ def six_plot(
         all_nan: bool
             Set this flag to True if the data to be plotted consist
             only of NaNs
-        plot_val: xarray DataArray or numpy.ndarray
-            Single variable GEOS-Chem output values to plot
+        plot_vals: xarray.DataArray, numpy.ndarray, or dask.array.Array
+            Single data variable GEOS-Chem output to plot
         grid: dict
             Dictionary mapping plot_val to plottable coordinates
         ax: matplotlib axes

--- a/gcpy/plot.py
+++ b/gcpy/plot.py
@@ -11,6 +11,7 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
+from dask.array import Array as DaskArray
 import xarray as xr
 import cartopy.crs as ccrs
 from matplotlib.backends.backend_pdf import PdfPages
@@ -167,7 +168,7 @@ def six_plot(
             or imshow() (Lat/Lon).
     """
     # TODO: Abstract six_plot and related routines out of plot.py
-    verify_variable_type(plot_val, (np.ndarray, xr.DataArray))
+    verify_variable_type(plot_val, (np.ndarray, xr.DataArray, DaskArray))
 
     # Compute the min & max values
     vmin, vmax = compute_vmin_vmax_for_plot(
@@ -1288,10 +1289,15 @@ def compare_single_level(
                 temp = minlon
                 minlon = maxlon
                 maxlon = temp
-            return ds_new.where(ds_new[lon_var] >= minlon, drop=True).\
-                where(ds_new[lon_var] <= maxlon, drop=True).\
-                where(ds_new[lat_var] >= minlat, drop=True).\
-                where(ds_new[lat_var] <= maxlat, drop=True)
+
+            # Add .compute() to force evaluation of ds_new[lon_var]
+            # See https://github.com/geoschem/gcpy/issues/254
+            # Also note: This may return as a dask.array.Array object
+            return ds_new.where(\
+                ds_new[lon_var].compute() >= minlon, drop=True).\
+                where(ds_new[lon_var].compute() <= maxlon, drop=True).\
+                where(ds_new[lat_var].compute() >= minlat, drop=True).\
+                where(ds_new[lat_var].compute() <= maxlat, drop=True)
 
         ds_ref_reg = get_extent_for_colors(
             ds_ref,
@@ -1624,6 +1630,7 @@ def compare_single_level(
         maxs = [vmax_ref, vmax_dev, vmax_abs]
 
         ratio_logs = [False, False, False, False, True, True]
+
         # Plot
         for i in range(6):
             six_plot(
@@ -2909,7 +2916,7 @@ def single_panel(
     Core plotting routine -- creates a single plot panel.
 
     Args:
-        plot_vals: xarray DataArray or numpy array
+        plot_vals: xarray.DataArray, numpy.ndarray, or dask.array.Array
             Single data variable GEOS-Chem output to plot
 
     Keyword Args (Optional):
@@ -3020,7 +3027,7 @@ def single_panel(
         plot: matplotlib plot
             Plot object created from input
     """
-    verify_variable_type(plot_vals, (xr.DataArray, np.ndarray))
+    verify_variable_type(plot_vals, (xr.DataArray, np.ndarray, DaskArray))
 
     # Create empty lists for keyword arguments
     if pres_range is None:


### PR DESCRIPTION
This PR fixes an issue that seems to have been introduced with recent versions of xarray.  The following updates were made:

(1) The following code in routine `get_extents_for_color` (in `gcpy/plot.py`):
  ```python
            return ds_new.where(\
                ds_new[lon_var] >= minlon, drop=True).\
                where(ds_new[lon_var] <= maxlon, drop=True).\
                where(ds_new[lat_var]>= minlat, drop=True).\
                where(ds_new[lat_var] <= maxlat, drop=True)
  ```
   needed to be changed to
  ```python
            # Add .compute() to force evaluation of ds_new[lon_var]
            # See https://github.com/geoschem/gcpy/issues/254
            # Also note: This may return as a dask.array.Array object
            return ds_new.where(\
                ds_new[lon_var].compute() >= minlon, drop=True).\
                where(ds_new[lon_var].compute() <= maxlon, drop=True).\
                where(ds_new[lat_var].compute() >= minlat, drop=True).\
                where(ds_new[lat_var].compute() <= maxlat, drop=True)
  ``` 
  as calling `where` with `drop=True` on an xarray object silently evaluates the data.  Using `.compute()` forces xarray to do the actual computation.  This behavior seems to have changed in xarray recently.  For a similar issue, see: https://github.com/hainegroup/oceanspy/issues/332.  The object returned also seems to be of type `dask.array.Array` instead of `xarray.DataArray` or `numpy.ndarray`.

(2) We now must add this import statement;
```python
from dask array import Array as DaskArray
```
so that we can add this to calls to `verify_variable_type`.

(3) We must now also add `DaskArray` to the calls to `verify_variable_type` in `six_plot` and `single_panel` in `plot.py`:
```python
    verify_variable_type(plot_val, (np.ndarray, xr.DataArray, DaskArray))
```

(4) Update Pydoc headers accordingly:
```python
        """
        ... etc ...

        plot_vals: xarray.DataArray, numpy.ndarray, or dask.array.Array
            Single data variable GEOS-Chem output to plot

        ... etc ...
        """
```

(5) Because these fixes allow benchmark plots to proceed, we can remove the pegged xarray from `environment.yml`
```yaml
    #
    # NOTE: The most recent xarray (2023.8.0) seems to break backwards
    # compatibility with the benchmark plotting code.  Peg to 2023.2.0
    # until we can update GCPy for the most recent xarray.
    #  -- Bob Yantosca (29 Aug 2023)
    #
    - xarray==2023.2.0                # Read data from netCDF etc files
```
and replace it with
```yaml
    - xarray                          # Read data from netCDF etc files```
```