### PR TITLE
Make benchmark configuration files consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed `gcpy_test_dir` option from `examples/diagnostics/compare_diags.*`
 - Removed `docs/environment_files/gchp_regridding.yml` environment file
 - Removed `gcpy/gcpy/benchmark/plot_driver.sh`
+- Made benchmark configuration files consistent
 
 ## [1.3.3] -- 2023-03-09
 ### Added

--- a/gcpy/benchmark/cloud/template.1hr_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1hr_benchmark.yml
@@ -4,15 +4,15 @@
 # customize in the following manner:
 #
 # (1) Edit the path variables so that they point to folders
-#     containing model data.
-# (2) Edit the version strings for each benchmark simulation.
+#     containing model data
+# (2) Edit the version strings for each benchmark simulation
 # (3) Edit the switches that turn on/off creating of plots and
-#     tables, as well as other plotting options.
+#     tables as well as other plotting options
 # (4) If necessary, edit labels for the dev and ref versions
 #
 # Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
 # to gcc_dev (not gcc_ref!). This ensures consistency in version names
-# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# when doing GCHP vs GCC diff-of-diffs.
 # =====================================================================
 #
 # Configuration for 1-hour FullChemBenchmark
@@ -76,11 +76,11 @@ data:
       is_pre_14.0: False
       resolution: c24
 #
-# options: Customizes the benchmark plot output.
+# options: Customizes the benchmark plot output
 #
 options:
   #
-  # bmk_type: Specifies the type of benchmark.
+  # bmk_type: Specifies the type of benchmark
   #
   bmk_type: FullChemBenchmark
   #
@@ -103,7 +103,7 @@ options:
       run: False
       dir: GCHP_GCC_diff_of_diffs
   #
-  # outputs: Specifies the plots and tables to generate.
+  # outputs: Specifies the plots and tables to generate
   #
   outputs:
     plot_conc: False

--- a/gcpy/benchmark/cloud/template.1mo_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1mo_benchmark.yml
@@ -4,18 +4,18 @@
 # customize in the following manner:
 #
 # (1) Edit the path variables so that they point to folders
-#     containing model data.
-# (2) Edit the version strings for each benchmark simulation.
+#     containing model data
+# (2) Edit the version strings for each benchmark simulation
 # (3) Edit the switches that turn on/off creating of plots and
-#     tables, as well as other plotting options.
+#     tables as well as other plotting options
 # (4) If necessary, edit labels for the dev and ref versions
 #
 # Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
 # to gcc_dev (not gcc_ref!). This ensures consistency in version names
-# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# when doing GCHP vs GCC diff-of-diffs.
 # =====================================================================
 #
-# Configuration for 1 month FullChemBenchmark
+# Configuration for 1-month FullChemBenchmark
 #
 # paths:
 #   main_dir:    High-level directory containing ref & dev rundirs
@@ -76,11 +76,11 @@ data:
       is_pre_14.0: False
       resolution: c24
 #
-# options: Customizes the benchmark plot output.
+# options: Customizes the benchmark plot output
 #
 options:
   #
-  # bmk_type: Specifies the type of benchmark.
+  # bmk_type: Specifies the type of benchmark
   #
   bmk_type: FullChemBenchmark
   #
@@ -103,7 +103,7 @@ options:
       run: False
       dir: GCHP_GCC_diff_of_diffs
   #
-  # outputs: Specifies the plots and tables to generate.
+  # outputs: Specifies the plots and tables to generate
   #
   outputs:
     plot_conc: True

--- a/gcpy/benchmark/config/1mo_benchmark.yml
+++ b/gcpy/benchmark/config/1mo_benchmark.yml
@@ -1,4 +1,4 @@
-&---
+---
 # =====================================================================
 # Benchmark configuration file (**EDIT AS NEEDED**)
 # customize in the following manner:
@@ -26,8 +26,8 @@
 #                species_database.yml in one of the Dev rundirs.
 #
 paths:
-  main_dir: /path/to/benchmark/main/dir    # EDIT AS NEEDED
-  results_dir: /path/to/BenchmarkResults   # EDIT AS NEEDED
+  main_dir: /path/to/benchmark/main/dir
+  results_dir: /path/to/BenchmarkResults
   weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
 #
@@ -47,7 +47,7 @@ data:
       dir: GCC_ref
       outputs_subdir: OutputDir
       restarts_subdir: Restarts
-      bmk_start: "2019-07-01T00:00:00" 
+      bmk_start: "2019-07-01T00:00:00"
       bmk_end: "2019-08-01T00:00:00"
     gchp:
       version: GCHP_ref
@@ -64,14 +64,14 @@ data:
       dir: GCC_dev
       outputs_subdir: OutputDir
       restarts_subdir: Restarts
-      bmk_start: "2019-07-01T00:00:00" 
+      bmk_start: "2019-07-01T00:00:00"
       bmk_end: "2019-08-01T00:00:00"
     gchp:
       version: GCHP_dev
       dir: GCHP_dev
       outputs_subdir: OutputDir
       restarts_subdir: Restarts
-      bmk_start: "2019-07-01T00:00:00" 
+      bmk_start: "2019-07-01T00:00:00"
       bmk_end: "2019-08-01T00:00:00"
       is_pre_14.0: False
       resolution: c24

--- a/gcpy/benchmark/config/1mo_benchmark.yml
+++ b/gcpy/benchmark/config/1mo_benchmark.yml
@@ -4,18 +4,18 @@
 # customize in the following manner:
 #
 # (1) Edit the path variables so that they point to folders
-#     containing model data.
-# (2) Edit the version strings for each benchmark simulation.
+#     containing model data
+# (2) Edit the version strings for each benchmark simulation
 # (3) Edit the switches that turn on/off creating of plots and
-#     tables, as well as other plotting options.
+#     tables as well as other plotting options
 # (4) If necessary, edit labels for the dev and ref versions
 #
 # Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
 # to gcc_dev (not gcc_ref!). This ensures consistency in version names
-# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# when doing GCHP vs GCC diff-of-diffs.
 # =====================================================================
 #
-# Configuration for 1 month FullChemBenchmark
+# Configuration for 1-month FullChemBenchmark
 #
 # paths:
 #   main_dir:    High-level directory containing ref & dev rundirs
@@ -28,7 +28,7 @@
 paths:
   main_dir: /path/to/benchmark/main/dir    # EDIT AS NEEDED
   results_dir: /path/to/BenchmarkResults   # EDIT AS NEEDED
-  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
+  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
 #
 # data: Contains configurations for ref and dev runs
@@ -76,34 +76,34 @@ data:
       is_pre_14.0: False
       resolution: c24
 #
-# options: Customizes the benchmark plot output.
+# options: Customizes the benchmark plot output
 #
 options:
   #
-  # bmk_type: Specifies the type of benchmark.
+  # bmk_type: Specifies the type of benchmark
   #
   bmk_type: FullChemBenchmark
   #
   # comparisons: Specifies the comparisons to perform.
   #
   comparisons:
-    gcc_vs_gcc: 
+    gcc_vs_gcc:
       run: True
       dir: GCC_version_comparison
       tables_subdir: Tables
-    gchp_vs_gcc: 
+    gchp_vs_gcc:
       run: True
-      dir: GCHP_GCC_comparison 
+      dir: GCHP_GCC_comparison
       tables_subdir: Tables
-    gchp_vs_gchp: 
+    gchp_vs_gchp:
       run: True
       dir: GCHP_version_comparison
       tables_subdir: Tables
-    gchp_vs_gcc_diff_of_diffs: 
+    gchp_vs_gcc_diff_of_diffs:
       run: True
       dir: GCHP_GCC_diff_of_diffs
   #
-  # outputs: Specifies the plots and tables to generate.
+  # outputs: Specifies the plots and tables to generate
   #
   outputs:
     plot_conc: True
@@ -117,13 +117,14 @@ options:
     OH_metrics: True
     ste_table: True # GCC only
     summary_table: True
-    plot_options: # Plot concentrations and emissions by category?
+    plot_options:
       by_spc_cat: True
       by_hco_cat: True
   #
-  # n_cores: Specify the number of cores to use:
-  # -1: Use all avaiable cores
-  # -N: Use N cores
+  # n_cores: Specify the number of cores to use.
+  # -1: Use $OMP_NUM_THREADS         cores
+  # -2: Use $OMP_NUM_THREADS - 1     cores
+  # -N: Use $OMP_NUM_THREADS - (N-1) cores
   #  1: Disable parallelization (use a single core)
   #
   n_cores: -1

--- a/gcpy/benchmark/config/1yr_ch4_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_ch4_benchmark.yml
@@ -4,18 +4,18 @@
 # customize in the following manner:
 #
 # (1) Edit the path variables so that they point to folders
-#     containing model data.
-# (2) Edit the version strings for each benchmark simulation.
-# (3) Edit the switches that turn on/off creating of plots and tables,
-#     as well as other plotting options.
-# (4) If necessary, edit labels for the dev and ref versions.
+#     containing model data
+# (2) Edit the version strings for each benchmark simulation
+# (3) Edit the switches that turn on/off creating of plots and
+#     tables as well as other plotting options
+# (4) If necessary, edit labels for the dev and ref versions
 #
 # Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
 # to gcc_dev (not gcc_ref!). This ensures consistency in version names
-# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# when doing GCHP vs GCC diff-of-diffs.
 # =====================================================================
 #
-# Configuration for 1yr CH4Benchmark
+# Configuration for 1-year CH4Benchmark
 #
 # paths:
 #   main_dir:    High-level directory containing ref & dev rundirs
@@ -56,11 +56,11 @@ data:
       restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_pre_14.0: False               # for gcpy_test_data, edit if needed
-      resolution: c24                  # for gcpy_test_data, edit if needed
+      is_pre_14.0: False
+      resolution: c24
   dev:
     gcc:
-      version: GCC_dev
+      version: GCC_dev 
       dir: GCC_dev
       outputs_subdir: OutputDir
       restarts_subdir: Restarts
@@ -73,37 +73,37 @@ data:
       restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_pre_14.0: False              # for gcpy_test_data, edit if needed
-      resolution: c24                 # for gcpy_test_data, edit if needed   
+      is_pre_14.0: False
+      resolution: c24
 #
-# options: Customize the benchmark plot output.
-# 
+# options: Customizes the benchmark plot output
+#
 options:
   #
-  # bmk_type: Specifies the type of benchmark.
+  # bmk_type: Specifies the type of benchmark
   #
   bmk_type: CH4Benchmark
   #
   # comparisons: Specifies the comparisons to perform.
   #
   comparisons:
-    gcc_vs_gcc: 
-      run: True # True to run this comparison
+    gcc_vs_gcc:
+      run: True
       dir: GCC_version_comparison
       tables_subdir: Tables
-    gchp_vs_gcc: 
-      run: False
-      dir: GCHP_GCC_comparison 
+    gchp_vs_gcc:
+      run: True
+      dir: GCHP_GCC_comparison
       tables_subdir: Tables
-    gchp_vs_gchp: 
-      run: False
+    gchp_vs_gchp:
+      run: True
       dir: GCHP_version_comparison
       tables_subdir: Tables
     gchp_vs_gcc_diff_of_diffs:
       run: False
       dir: GCHP_GCC_diff_of_diffs
   #
-  # outputs: Specifies the plots and tables to generate.
+  # outputs: Specifies the plots and tables to generate
   #
   outputs:
     plot_conc: True

--- a/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
@@ -1,4 +1,4 @@
-&---
+---
 # =====================================================================
 # Benchmark configuration file (**EDIT AS NEEDED**)
 # customize in the following manner:
@@ -27,8 +27,8 @@
 #   obs_data_dir: Path to observational data (for models vs obs plots)
 #
 paths:
-  main_dir: /path/to/benchmark/main/dir    # EDIT AS NEEDED
-  results_dir: /path/to/BenchmarkResults   # EDIT AS NEEDED
+  main_dir: /path/to/benchmark/main/dir
+  results_dir: /path/to/BenchmarkResults
   weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
   obs_data_dir: /path/to/observational/data

--- a/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
@@ -7,15 +7,15 @@
 #     containing model data
 # (2) Edit the version strings for each benchmark simulation
 # (3) Edit the switches that turn on/off creating of plots and
-#     tables as well as other plotting options.
+#     tables as well as other plotting options
 # (4) If necessary, edit labels for the dev and ref versions
 #
 # Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
 # to gcc_dev (not gcc_ref!). This ensures consistency in version names
-# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# when doing GCHP vs GCC diff-of-diffs.
 # =====================================================================
 #
-# Configuration for 1yr FullChemBenchmark
+# Configuration for 1-year FullChemBenchmark
 #
 # paths:
 #   main_dir:     High-level directory containing ref & dev rundirs
@@ -48,7 +48,7 @@ data:
       version: GCC_ref
       dir: GCC_ref
       outputs_subdir: OutputDir
-      restarts_subdir: restarts
+      restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
     gchp:
@@ -58,14 +58,14 @@ data:
       restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_pre_14.0: True                # for gcpy_test_data, edit if needed
-      resolution: c48                  # for gcpy_test_data, edit if needed
+      is_pre_14.0: False
+      resolution: c24
   dev:
     gcc:
       version: GCC_dev 
       dir: GCC_dev
       outputs_subdir: OutputDir
-      restarts_subdir: restarts
+      restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
     gchp:
@@ -75,11 +75,11 @@ data:
       restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_pre_14.0: False              # for gcpy_test_data, edit if needed
-      resolution: c24                 # for gcpy_test_data, edit if needed   
+      is_pre_14.0: False
+      resolution: c24
 #
-# options: Customize the benchmark plot output.
-# 
+# options: Customizes the benchmark plot output
+#
 options:
   #
   # bmk_type: Specifies the type of benchmark
@@ -89,15 +89,15 @@ options:
   # comparisons: Specifies the comparisons to perform.
   #
   comparisons:
-    gcc_vs_gcc: 
-      run: True # True to run this comparison
+    gcc_vs_gcc:
+      run: True
       dir: GCC_version_comparison
       tables_subdir: Tables
-    gchp_vs_gcc: 
+    gchp_vs_gcc:
       run: True
-      dir: GCHP_GCC_comparison 
+      dir: GCHP_GCC_comparison
       tables_subdir: Tables
-    gchp_vs_gchp: 
+    gchp_vs_gchp:
       run: True
       dir: GCHP_version_comparison
       tables_subdir: Tables
@@ -105,7 +105,7 @@ options:
       run: True
       dir: GCHP_GCC_diff_of_diffs
   #
-  # outputs: Types of output to generate (plots/tables)
+  # outputs: Specifies the plots and tables to generate
   #
   outputs:
     plot_conc: True

--- a/gcpy/benchmark/config/1yr_tt_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_tt_benchmark.yml
@@ -1,4 +1,4 @@
-&---
+---
 # =====================================================================
 # Benchmark configuration file (**EDIT AS NEEDED**)
 # customize in the following manner:
@@ -26,8 +26,8 @@
 #                species_database.yml in one of the Dev rundirs.
 #
 paths:
-  main_dir: /path/to/benchmark/main/dir   # EDIT AS NEEDED
-  results_dir: /path/to/BenchmarkResults  # EDIT AS NEEDED
+  main_dir: /path/to/benchmark/main/dir
+  results_dir: /path/to/BenchmarkResults
   weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
 #

--- a/gcpy/benchmark/config/1yr_tt_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_tt_benchmark.yml
@@ -3,19 +3,19 @@
 # Benchmark configuration file (**EDIT AS NEEDED**)
 # customize in the following manner:
 #
-# (1) Edit the path variables so that they point to folders w/
-#     containing model data.
-# (2) Edit the version strings for each benchmark simulation.
+# (1) Edit the path variables so that they point to folders
+#     containing model data
+# (2) Edit the version strings for each benchmark simulation
 # (3) Edit the switches that turn on/off creating of plots and
-#     tables, as well as other plotting options.
-# (4) If necessary, edit labels for the dev and ref versions.
+#     tables as well as other plotting options
+# (4) If necessary, edit labels for the dev and ref versions
 #
 # Note: When doing GCHP vs GCC comparisions gchp_dev will be compared
 # to gcc_dev (not gcc_ref!). This ensures consistency in version names
-# when doing GCHP vs GCC diff-of-diffs (mps, 6/27/19)
+# when doing GCHP vs GCC diff-of-diffs.
 # =====================================================================
 #
-# Configuration for 1 year TransportTracersBenchmark
+# Configuration for 1-year TransportTracersBenchmark
 #
 # paths:
 #   main_dir:    High-level directory containing ref & dev rundirs
@@ -56,11 +56,11 @@ data:
       restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_pre_14.0: True               # for gcpy_test_data, edit if needed
-      resolution: c48                 # for gcpy_test_data, edit if needed
+      is_pre_14.0: False
+      resolution: c24
   dev:
     gcc:
-      version: GCC_dev
+      version: GCC_dev 
       dir: GCC_dev
       outputs_subdir: OutputDir
       restarts_subdir: Restarts
@@ -73,14 +73,14 @@ data:
       restarts_subdir: Restarts
       bmk_start: "2019-01-01T00:00:00"
       bmk_end: "2020-01-01T00:00:00"
-      is_pre_14.0: True               # for gcpy_test_data, edit if needed
-      resolution: c48                 # for gcpy_test_data, edit if needed
+      is_pre_14.0: False
+      resolution: c24
 #
-# options: Customize the benchmark plot output.
+# options: Customizes the benchmark plot output
 #
 options:
   #
-  # bmk_type: Specifies the type of benchmark.
+  # bmk_type: Specifies the type of benchmark
   #
   bmk_type: TransportTracersBenchmark
   #
@@ -99,9 +99,11 @@ options:
       run: True
       dir: GCHP_version_comparison
       tables_subdir: Tables
-    # GCHP vs GCC diff of diffs not included in 1-yr tt benchmark
+    gchp_vs_gcc_diff_of_diffs:
+      run: False
+      dir: GCHP_GCC_diff_of_diffs
   #
-  # outputs: Specifies the plots and tables to generate.
+  # outputs: Specifies the plots and tables to generate
   #
   outputs:
     plot_conc: True


### PR DESCRIPTION
- Fixed comments so they are consistent in gcpy/benchmark/config/*.yml
- Changed default gchp resolution to c24
- Set gchp switch is_pre_14.0: False by default