### PR TITLE
Fixed online regridding code (file_regrid.py) for restart-to-restart file regridding only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Now allow `plot_val` to be of type `dask.array.Array` in `plot.py` routines `six_plot` and `single_panel`
 - Now add `if` statements to turn of `Parallel()` commands when `n_jobs==1`.
 - Do not hardwire fontsize in `gcpy/plot.py`; get defaults from `gcpy_plot_style`
+- Updated and cleaned up code in `gcpy/regrid.py`
+- Example scripts`plot_single_level` and `plot_comparisons` can now accept command-line arguments
+- Example scripts `plot_single_level.py`, `plot_comparisons.py`, `compare_diags.py` now handle GCHP restart files properly
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`
@@ -366,16 +369,3 @@ This is the first labeled version of GCPy. The primary functionality of GCPy is 
 - Support for plotting benchmark output for both GEOS-Chem Classic (lat/lon data) and GCHP (cubed-sphere data).
 
 The first official release version of GCPy, v1.0.0, will correspond with the release of GEOS-Chem 13.0.0.
-
-
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Fixed
-
-### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added statement `from dask.array import Array as DaskArray` in `gcpy plot.py`
 - Added SLURM run script `gcpy/benchmark/benchmark_slurm.sh`
 - Added `gcpy/gcpy_plot_style` style sheet for title and label default settings
+- Added new cubed-sphere grid inquiry functions to `gcpy/cstools.py`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added SLURM run script `gcpy/benchmark/benchmark_slurm.sh`
 - Added `gcpy/gcpy_plot_style` style sheet for title and label default settings
 - Added new cubed-sphere grid inquiry functions to `gcpy/cstools.py`
+- Added function `get_lev_and_ilev` to `gcpy/grid.py`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added SLURM run script `gcpy/benchmark/benchmark_slurm.sh`
 - Added `gcpy/gcpy_plot_style` style sheet for title and label default settings
 - Added new cubed-sphere grid inquiry functions to `gcpy/cstools.py`
-- Added function `get_lev_and_ilev` to `gcpy/grid.py`
+- Added functions `get_ilev_coord` and `get_lev_coord` to `gcpy/grid.py`
 
 ### Changed
 - Simplified the Github issues templates into two options: `new-feature-or-discussion.md` and `question-issue.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent plot panels from overlapping in six-panel plots
 - Prevent colorbar tick labels from overlapping in dynamic-range ratio plots
 - Updated `seaborn` plot style names to conform to the latest matplotlib
+- Set `lev:positive="down"` in `regrid_restart_file.py` when regridding to GCHP restart files
 
 ### Removed
 - Removed `gchp_is_pre_13_1` arguments & code from benchmarking routines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prevent plot panels from overlapping in six-panel plots
 - Prevent colorbar tick labels from overlapping in dynamic-range ratio plots
 - Updated `seaborn` plot style names to conform to the latest matplotlib
-- Set `lev:positive="down"` in `regrid_restart_file.py` when regridding to GCHP restart files
+- Set `lev:positive` and/or `ilev:positive` properly in `regrid_restart_file.py` and `file_regrid.py`
+- Prevent overwriting of `lev` coord in `file_regrid.py` at netCDF write time
 
 ### Removed
 - Removed `gchp_is_pre_13_1` arguments & code from benchmarking routines

--- a/gcpy/cstools.py
+++ b/gcpy/cstools.py
@@ -740,8 +740,9 @@ def is_cubed_sphere_rst_grid(data):
     """
     gcpy.util.verify_variable_type(data, (xr.DataArray, xr.Dataset))
 
-    if data.dims["lat"] ==  data.dims["lon"] * 6:
-        return True
+    if "lat" in data.dims:
+        if data.dims["lat"] == data.dims["lon"] * 6:
+            return True
     if "SPC_" in data.data_vars.keys():
         return True
     return False
@@ -769,4 +770,4 @@ def get_cubed_sphere_res(data):
         return 0
     if is_cubed_sphere_rst_grid(data):
         return data.dims["lon"]
-    return data["Xdim"]
+    return data.dims["Xdim"]

--- a/gcpy/examples/diagnostics/compare_diags.py
+++ b/gcpy/examples/diagnostics/compare_diags.py
@@ -4,8 +4,6 @@ Example script that can compare diagnostics from two different netCDF
 collections.  Similar to compute_diagnostics.ipynb, but can be used
 without having to open a Jupyter notebook.
 """
-
-# Imports
 import os
 import sys
 import warnings
@@ -98,6 +96,10 @@ def read_data(config):
     except Exception as exc:
         msg = "Error reading " + dev_file
         raise Exception(msg) from exc
+
+    # Special handling for GCHP restart files
+    refdata = util.rename_and_flip_gchp_rst_vars(refdata)
+    devdata = util.rename_and_flip_gchp_rst_vars(devdata)
 
     # Define dictionary for return
     data = {
@@ -303,8 +305,7 @@ def compare_data(config, data):
     # ==================================================================
     # Print totals for each quantity
     # ==================================================================
-    if config["options"]["totals_and_diffs"]["create_table"] or \
-       config["options"]["totals_and_diffs"]["print_to_screen"]:
+    if config["options"]["totals_and_diffs"]["create_table"]:
         print('... Printing totals and differences')
         print_totals_and_diffs(
             config,

--- a/gcpy/examples/plotting/plot_comparisons.py
+++ b/gcpy/examples/plotting/plot_comparisons.py
@@ -12,29 +12,51 @@ points in one run that are stored in separate xarray datasets.
 The example data described here is in lat/lon format, but the same
 code works equally well for cubed-sphere (GCHP) data.
 """
+import argparse
 import xarray as xr
+from matplotlib import use as mpl_use
 import matplotlib.pyplot as plt
 from gcpy import plot
 from gcpy.constants import skip_these_vars
+from gcpy.util import rename_and_flip_gchp_rst_vars
 
-def main():
+# X11 backend needed for plt.show()
+mpl_use("tkagg")
+
+
+def plot_comparisons(
+        ref,
+        dev,
+        varname,
+        level
+):
     """
     Example function to create six-panel comparison plots.
-    """
 
+    Args:
+    -----
+    ref     (str) : Path to the "Ref" data file.
+    dev     (str) : Path to the "Dev" data file.
+    varname (str) : Variable to plot
+    level   (int) : Level to plot (for single-level comparisons only).
+    """
     # xarray allows us to read in any NetCDF file, the format of
     # GEOS-Chem diagnostics, #as an xarray Dataset
     #
     # The skip_these_vars list avoids trying to read certain
     # GCHP variables that cause data read issues.
     ref_ds = xr.open_dataset(
-        'first_run/GEOSChem.Restart.20160801_0000z.nc4',
+        ref,
         drop_variables=skip_these_vars
     )
     dev_ds = xr.open_dataset(
-        'second_run/GEOSChem.Restart.20160801_0000z.nc4',
+        dev,
         drop_variables=skip_these_vars
     )
+
+    # Special handling is needed for GCHP restart files
+    ref_ds = rename_and_flip_gchp_rst_vars(ref_ds)
+    dev_ds = rename_and_flip_gchp_rst_vars(dev_ds)
 
     # ==================
     # Single level plots
@@ -42,17 +64,18 @@ def main():
 
     # compare_single_level generates sets of six panel plots for
     # data at a specified level in your datasets.  By default, the
-    # level at index 0 (likely the surface) is plotted. Here we will
-    # plot data at ~500 hPa, which is located at index 21 in the
-    # standard 72-level and 47-level GMAO vertical grids.
-    ilev=21
-
+    # level at index 0 (likely the surface) is plotted.
+    #
     # You likely want to look at the same variables across both of
     # your datasets. If a variable is in one dataset but not the other,
     # the plots will show NaN values for the latter.  You can pass
     # variable names in a list to these comparison plotting functions
     # (otherwise all variables will plot).
-    varlist = ['SpeciesRst_O3', 'SpeciesRst_CO2']
+    #
+    # NOTE: For simplicity, we will just restrict the comparisons
+    # to a single variable.  But you can add as many variables as
+    # you like to varlist.
+    varlist = [varname]
 
     # compare_single_level has many arguments which can be optionally
     # specified. The first four arguments are required.  They specify
@@ -62,10 +85,10 @@ def main():
     # variables you want to plot.
     plot.compare_single_level(
         ref_ds,
-        'Dataset 1',
+        'Ref version',
         dev_ds,
-        'Dataset 2',
-        ilev=ilev,
+        'Dev version',
+        ilev=level,
         varlist=varlist
     )
     plt.show()
@@ -74,10 +97,10 @@ def main():
     # You can also save out the plots to a PDF.
     plot.compare_single_level(
         ref_ds,
-        'Dataset 1',
+        'Ref version',
         dev_ds,
-        'Dataset 2',
-        ilev=ilev,
+        'Dev version',
+        ilev=level,
         varlist=varlist,
         pdfname='single_level.pdf'
     )
@@ -93,15 +116,64 @@ def main():
     # default every vertical level is plotted)
     plot.compare_zonal_mean(
         ref_ds,
-        'Dataset 1',
+        'Ref version',
         dev_ds,
-        'Dataset 2',
+        'Dev version',
         pres_range=[0, 100],
         varlist=varlist,
         pdfname='zonal_mean.pdf'
     )
 
 
-# Only execute when we run as a standalone script
-if __name__ == '__main__':
+def main():
+    """
+    Parses command-line arguments and calls plot_comparisons
+    """
+
+    # Tell the parser which arguments to look for
+    parser = argparse.ArgumentParser(
+        description="Single-panel plotting example program"
+    )
+    parser.add_argument(
+        "-r", "--ref",
+        metavar="REF",
+        type=str,
+        required=True,
+        help="path to NetCDF file for the Ref model"
+    )
+    parser.add_argument(
+        "-d", "--dev",
+        metavar="DEV",
+        type=str,
+        required=True,
+        help="path to NetCDF file for the Dev model"
+    )
+    parser.add_argument(
+        "-v", "--varname",
+        metavar="VAR",
+        type=str,
+        required=True,
+        help="Variable name to plot"
+    )
+    parser.add_argument(
+        "-l", "--level",
+        metavar="LEV",
+        type=int,
+        required=True,
+        help="level to plot (single-level plots only), starting at 0"
+    )
+
+    # Parse command-line arguments
+    args = parser.parse_args()
+
+    # Call the plot_single_panel routine
+    plot_comparisons(
+        args.ref,
+        args.dev,
+        args.varname,
+        args.level
+    )
+
+
+if __name__ == "__main__":
     main()

--- a/gcpy/examples/plotting/plot_single_panel.py
+++ b/gcpy/examples/plotting/plot_single_panel.py
@@ -13,19 +13,34 @@ For full documentation on the plotting capabilities of GCPy
 (including full argument lists), please see the GCPy documentation
 at https://gcpy.readthedocs.io.
 """
+import argparse
 import xarray as xr
+from matplotlib import use as mpl_use
 import matplotlib.pyplot as plt
 from gcpy import plot
+from gcpy.util import rename_and_flip_gchp_rst_vars
+
+# X11 backend needed for plt.show()
+mpl_use("tkagg")
 
 
-def main():
+def plot_single_panel(infile, varname, level):
     """
     Example routine to create single panel plots.
+
+    Args:
+    -----
+    infile  (str) : Name of netCDF file to read.
+    varname (str) : Name of variable to plot
+    level   (int) : Model level for single-panel plots
+                    in Python notation (starting from 0)
     """
 
-    # xarray allows us to read in any NetCDF file, the format of
-    # GEOS-Chem diagnostics as an xarray Dataset
-    dset = xr.open_dataset('GEOSChem.Restart.20160701_0000z.nc4')
+    # xarray allows us to read in any NetCDF file
+    dset = xr.open_dataset(infile)
+
+    # Special handling if the file is a GCHP restart file
+    dset = rename_and_flip_gchp_rst_vars(dset)
 
     # You can easily view the variables available for plotting
     # using xarray.  Each of these variables has its own xarray
@@ -35,15 +50,11 @@ def main():
     # Most variables have some sort of prefix; in this example all
     # variables are prefixed with 'SpeciesRst_'. We'll select the
     # DataArray for ozone.
-    darr = dset.SpeciesRst_O3
+    darr = dset[varname]
 
     # Printing a DataArray gives a summary of the dimensions and attributes
     # of the data.
     print(darr)
-
-    # This Restart file has a time dimension of size 1, with 72 vertical levels,
-    #46 latitude indicies, and 72 longitude indices.
-
 
     # ==================
     # Single-level Plots
@@ -51,10 +62,9 @@ def main():
 
     # gcpy.single_panel is the core plotting function of GCPy, able to
     # create a one panel zonal mean or single level plot.  Here we will
-    # create a single level plot of ozone at ~500 hPa.  We must manually
-    # index into the level that we want to plot (index 22 in the standard
-    # 72-layer and 47-layer GMAO vertical grids).
-    slice_500 = darr.isel(lev=22)
+    # create a single level plot. We must manually index into the level
+    # (in Python notation, starting from 0).
+    darr_single_level = darr.isel(lev=level)
 
     # single_panel has many arguments which can be optionally specified.
     # The only argument you must always pass to a call to single_panel is
@@ -62,14 +72,21 @@ def main():
     # includes a colorbar with units read from the DataArray, an
     # automatic title (the data variable name in the DataArray), and
     # an extent equivalent to the full lat/lon extent of the DataArray
-    plot.single_panel(slice_500)
+    plot.single_panel(
+        darr_single_level,
+        title=f"{varname} at level {level}"
+    )
     plt.show()
 
-    #You can specify a specific area of the globe you would like plotted
+    # You can specify a specific area of the globe you would like plotted
     # using the 'extent' argument, which uses the format [min_longitude,
     # max_longitude, min_latitude, max_latitude] with bounds
     # [-180, 180, -90, 90]
-    plot.single_panel(slice_500, extent=[50, -90, -10, 60])
+    plot.single_panel(
+        darr_single_level,
+        extent=[50, -90, -10, 60],
+        title=f"{varname} at level {level} over N. Pacific"
+    )
     plt.show()
 
     # Other commonly used arguments include specifying a title and a
@@ -77,8 +94,8 @@ def main():
     #You can find more colormaps at
     # https://matplotlib.org/tutorials/colors/colormaps.html
     plot.single_panel(
-        slice_500,
-        title='500mb Ozone over the North Pacific',
+        darr_single_level,
+        title=f"{varname} at level {level} over N. Pacific, viridis colormap",
         comap=plt.get_cmap("viridis"),
         log_color_scale=True,
         extent=[80, -90, -10, 60]
@@ -89,25 +106,68 @@ def main():
     # Zonal Mean Plotting
     # ===================
 
-    #Use the plot_type argument to specify zonal_mean plotting
+    # Use the plot_type argument to specify zonal_mean plotting
     plot.single_panel(
         darr,
-        plot_type="zonal_mean"
+        plot_type="zonal_mean",
+        title=f"Zonal mean plot for {varname}, full atmosphere"
     )
     plt.show()
 
-    #You can specify pressure ranges in hPa for zonal mean plot
+    # You can specify pressure ranges in hPa for zonal mean plot
     # (by default every vertical level is plotted)
     plot.single_panel(
         darr,
         pres_range=[0, 100],
         log_yaxis=True,
-        log_color_scale=True
+        log_color_scale=True,
+        plot_type="zonal_mean",
+        title=f"Zonal mean plot for {varname}, stratopshere-only"
     )
     plt.show()
 
 
+def main():
+    """
+    Parses command-line arguments and calls plot_single_panel.
+    """
 
-# Only execute when we run as a standalone script
-if __name__ == '__main__':
+    # Tell the parser which arguments to look for
+    parser = argparse.ArgumentParser(
+        description="Single-panel plotting example program"
+    )
+    parser.add_argument(
+        "-i", "--infile",
+        metavar="INF",
+        type=str,
+        required=True,
+        help="input NetCDF file"
+    )
+    parser.add_argument(
+        "-v", "--varname",
+        metavar="VARNAME",
+        type=str,
+        required=True,
+        help="variable to plot"
+    )
+    parser.add_argument(
+        "-l", "--level",
+        metavar="LEV",
+        type=int,
+        required=True,
+        help="level to plot (single-panel plots only), starting at 0"
+    )
+
+    # Parse command-line arguments
+    args = parser.parse_args()
+
+    # Call the plot_single_panel routine
+    plot_single_panel(
+        args.infile,
+        args.varname,
+        args.level
+    )
+
+
+if __name__ == "__main__":
     main()

--- a/gcpy/grid.py
+++ b/gcpy/grid.py
@@ -1,10 +1,14 @@
+"""
+Module containing variables and functions that define and
+manipulate GEOS-Chem horizontal and vertical grids
+"""
 import xarray as xr
 import numpy as np
 import scipy.sparse
 from itertools import product
-from .util import get_shape_of_data
+from gcpy.util import get_shape_of_data, verify_variable_type
 from .grid_stretching_transforms import scs_transform
-from .constants import R_EARTH_m
+from gcpy.constants import R_EARTH_m
 
 
 def get_troposphere_mask(ds):
@@ -165,7 +169,7 @@ def call_make_grid(res, gridtype, in_extent=[-180, 180, -90, 90],
 
     Returns:
         [grid, grid_list]: list(dict, list(dict))
-            Returns the created grid. 
+            Returns the created grid.
             grid_list is a list of grids if gridtype is 'cs', else it is None
     """
 
@@ -286,6 +290,72 @@ def get_vert_grid(dataset, AP=[], BP=[]):
     else:
         new_grid = vert_grid(AP, BP)
         return new_grid.p_edge(), new_grid.p_mid(), np.size(AP)
+
+
+def get_lev_and_ilev(
+        n_lev=72,
+        AP_edge=None,
+        BP_edge=None
+):
+    """
+    Returns the eta values (defined as (A/P0) + B) at vertical
+    level edges and midpoints.  These are used to define the
+    "lev" and "ilev" netCDF coordinate values.
+
+    Keyword Args (optional):
+    ------------------------
+    n_lev : int
+        Number of levels in the grid.  Default = 72
+    AP_edge : list-like
+        Hybrid grid parameter A (hPa), with values placed on level
+        edges.  If not specified, values from the _GEOS_72L_AP array
+        in this module will be used.
+    AP_edge : list-like
+        Hybrid grid parameter B (unitless), with values placed on level
+        edges.  If not specified, values from the _GEOS_72L_BP array in
+        this module will be used.
+
+    Returns:
+    --------
+    lev : xr.DataArray
+        List of eta values at vertical grid midpoints
+    ilev : xr.DataArray
+        List of eta values at vertical grid edges
+    """
+    if n_lev is None:
+        n_lev = 72
+    if AP_edge is None and n_lev == 72:
+        AP_edge = _GEOS_72L_AP
+    if AP_edge is None and n_lev == 47:
+        AP_edge = _GEOS_47L_AP
+    if BP_edge is None and n_lev == 72:
+        BP_edge = _GEOS_72L_BP
+    if BP_edge is None and n_lev == 47:
+        BP_edge = _GEOS_47L_BP
+
+    # Edges
+    AP_edge = np.array(AP_edge)
+    BP_edge = np.array(BP_edge)
+    ilev = xr.DataArray(
+        np.array((AP_edge/1000.0) + BP_edge, np.float64),
+        attrs={
+            "long_name": "hybrid level at interfaces ((A/P0)+B)",
+            "units": "level"
+            }
+        )
+
+    # Midpoints
+    AP_mid = (AP_edge[0:n_lev:1] + AP_edge[1:n_lev+1:1]) * 0.5
+    BP_mid = (BP_edge[0:n_lev:1] + BP_edge[1:n_lev+1:1]) * 0.5
+    lev = xr.DataArray(
+        np.array((AP_mid/1000.0) + BP_mid, np.float64),
+        attrs={
+            "long_name": "hybrid level at midpoints ((A/P0)+B)",
+            "units": "level"
+            }
+        )
+
+    return lev, ilev
 
 
 def get_pressure_indices(pedge, pres_range):
@@ -1121,7 +1191,7 @@ class CSGrid(object):
             pp[:, i, j] = latlon_to_cartesian(
                 lambda_rad[i, j], theta_rad[i, j])
 
-        # Map the edges on the sphere back to the cube. 
+        # Map the edges on the sphere back to the cube.
         #Note that all intersections are at x = -rsq3
         # print("EDGES")
         for ij in range(1, c + 1):

--- a/gcpy/grid.py
+++ b/gcpy/grid.py
@@ -295,7 +295,8 @@ def get_vert_grid(dataset, AP=[], BP=[]):
 def get_ilev_coord(
         n_lev=72,
         AP_edge=None,
-        BP_edge=None
+        BP_edge=None,
+        top_down=False
 ):
     """
     Returns the eta values (defined as (A/P0) + B) at vertical
@@ -344,7 +345,7 @@ def get_lev_coord(
         n_lev=72,
         AP_edge=None,
         BP_edge=None,
-        top_down=True
+        top_down=False
 ):
     """
     Returns the eta values (defined as (A/P0) + B) at vertical

--- a/gcpy/grid.py
+++ b/gcpy/grid.py
@@ -314,10 +314,13 @@ def get_ilev_coord(
         Hybrid grid parameter B (unitless), with values placed on level
         edges.  If not specified, values from the _GEOS_72L_BP array in
         this module will be used.
+    top_down : bool
+        Set this to true if the eta coordinate will be arranged from
+        top-of-atm downward (True) or from the surface upward (False).
 
     Returns:
     --------
-    ilev : xr.DataArray
+    ilev : numpy.ndarray
         List of eta values at vertical grid edges
     """
     if n_lev is None:
@@ -331,19 +334,17 @@ def get_ilev_coord(
     if BP_edge is None and n_lev == 47:
         BP_edge = _GEOS_47L_BP
 
-    return xr.DataArray(
-        np.array((AP_edge/1000.0) + BP_edge, np.float64),
-        attrs={
-            "long_name": "hybrid level at interfaces ((A/P0)+B)",
-            "units": "level"
-            }
-        )
-
+    # Get eta values at vertical level edges
+    ilev = np.array((AP_edge/1000.0) + BP_edge, dtype=np.float64)
+    if top_down:
+        ilev = ilev[::-1]
+    return ilev
 
 def get_lev_coord(
         n_lev=72,
         AP_edge=None,
-        BP_edge=None
+        BP_edge=None,
+        top_down=True
 ):
     """
     Returns the eta values (defined as (A/P0) + B) at vertical
@@ -362,10 +363,13 @@ def get_lev_coord(
         Hybrid grid parameter B (unitless), with values placed on level
         edges.  If not specified, values from the _GEOS_72L_BP array in
         this module will be used.
+    top_down : bool
+        Set this to true if the eta coordinate will be arranged from
+        top-of-atm downward (True) or from the surface upward (False).
 
     Returns:
     --------
-    lev : xr.DataArray
+    lev : numpy.ndarray
         List of eta values at vertical grid midpoints
     """
     if n_lev is None:
@@ -383,18 +387,13 @@ def get_lev_coord(
     # Convert inputs to numpy.ndarray for fast computation
     AP_edge = np.array(AP_edge)
     BP_edge = np.array(BP_edge)
-
-    # Midpoints
     AP_mid = (AP_edge[0:n_lev:1] + AP_edge[1:n_lev+1:1]) * 0.5
     BP_mid = (BP_edge[0:n_lev:1] + BP_edge[1:n_lev+1:1]) * 0.5
+    lev = np.array((AP_mid / 1000.0) + BP_mid, dtype=np.float64)
+    if top_down:
+        lev = lev[::-1]
+    return lev
 
-    return xr.DataArray(
-        np.array((AP_mid/1000.0) + BP_mid, np.float64),
-        attrs={
-            "long_name": "hybrid level at midpoints ((A/P0)+B)",
-            "units": "level"
-            }
-        )
 
 def get_pressure_indices(pedge, pres_range):
     """

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -731,7 +731,7 @@ def reformat_dims(
         ds: xarray Dataset
              Original dataset with reformatted dimensions
     """
-    def unravel_checkpoint(ds_in):
+    def unravel_checkpoint_lat(ds_in):
         if isinstance(ds_in, xr.Dataset):
             cs_res = ds_in.dims['lon']
             assert cs_res == ds_in.dims['lat'] // 6
@@ -742,32 +742,27 @@ def reformat_dims(
             np.linspace(1, 6, 6),
             np.linspace(1, cs_res, cs_res)
         ])
-        ds_in = ds_in.assign_coords({"lat": mi, "lon": mi})
+        ds_in = ds_in.assign_coords({"lat": mi})
         ds_in = ds_in.unstack('lat')
-        ds_in = ds_in.unstack('lon')
         return ds_in
 
-    def ravel_checkpoint(ds_out):
-        print(ds_out.dims)
-        print(ds_out.coords)
+    def ravel_checkpoint_lat(ds_out):
         if isinstance(ds, xr.Dataset):
             cs_res = ds_out.dims['lon']
         else:
             cs_res = ds_out['lon'].size
         ds_out = ds_out.stack(lat=['lat_level_0', 'lat_level_1'])
-        ds_out = ds_out.stack(lon=['lon_level_0', 'lon_level_1'])
         ds_out = ds_out.assign_coords({
             'lat': np.linspace(1, 6 * cs_res, 6 * cs_res),
-            'lon': np.linspace(1, cs_res, cs_res)
         })
         return ds_out
 
     dim_formats = {
         'checkpoint': {
-            'unravel': [unravel_checkpoint],
-            'ravel': [ravel_checkpoint],
+            'unravel': [unravel_checkpoint_lat],
+            'ravel': [ravel_checkpoint_lat],
             'rename': {
-                'lon_level_1': 'X',
+                'lon': 'X',
                 'lat_level_0': 'F',
                 'lat_level_1': 'Y',
                 'time': 'T',

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -1,5 +1,6 @@
-''' Functions for creating xesmf regridder objects '''
-
+"""
+Module containing functions for creating xESMF regridder objects.
+"""
 import os
 import warnings
 import hashlib
@@ -778,7 +779,7 @@ def reformat_dims(
                 'Ydim': 'Y',
                 'time': 'T',
             },
-            'transpose': ('time', 'lev', 'nf', 'Ydim', 'Xdim')
+            'transpose': ('time', 'lev', 'nf', 'Xdim', 'Ydim')
         }
     }
 

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -1,20 +1,24 @@
 ''' Functions for creating xesmf regridder objects '''
 
 import os
-import xesmf as xe
-from .grid import make_grid_LL, make_grid_CS, make_grid_SG, get_input_res, call_make_grid, \
-    get_grid_extents, get_vert_grid
+import warnings
 import hashlib
+import xesmf as xe
 import numpy as np
 import xarray as xr
 import pandas as pd
 import scipy.sparse
-import warnings
+from gcpy.grid import make_grid_LL, make_grid_CS, make_grid_SG, \
+    get_input_res, call_make_grid, get_grid_extents, get_vert_grid
 
 def make_regridder_L2L(
-        llres_in, llres_out, weightsdir='.', reuse_weights=False,
+        llres_in,
+        llres_out,
+        weightsdir='.',
+        reuse_weights=False,
         in_extent=[-180, 180, -90, 90],
-        out_extent=[-180, 180, -90, 90]):
+        out_extent=[-180, 180, -90, 90]
+):
     """
     Create an xESMF regridder between two lat/lon grids
 
@@ -64,11 +68,11 @@ def make_regridder_L2L(
         weightsfile = os.path.join(
             weightsdir, 'conservative_{}_{}_{}_{}.nc'.format(
                 llres_in, llres_out, in_extent_str, out_extent_str))
-        
+
     if not os.path.isfile(weightsfile) and reuse_weights:
         #prevent error with more recent versions of xesmf
         reuse_weights=False
-        
+
     try:
         regridder = xe.Regridder(
             llgrid_in,
@@ -86,8 +90,13 @@ def make_regridder_L2L(
     return regridder
 
 
-def make_regridder_C2L(csres_in, llres_out, weightsdir='.',
-                       reuse_weights=True, sg_params=[1, 170, -90]):
+def make_regridder_C2L(
+        csres_in,
+        llres_out,
+        weightsdir='.',
+        reuse_weights=True,
+        sg_params=[1, 170, -90]
+):
     """
     Create an xESMF regridder from a cubed-sphere to lat/lon grid
 
@@ -132,7 +141,7 @@ def make_regridder_C2L(csres_in, llres_out, weightsdir='.',
         else:
             weights_fname = f'conservative_sg{sg_hash(csres_in, sf_in, tlat_in, tlon_in)}_ll{llres_out}_F{i}.nc'
             weightsfile = os.path.join(weightsdir, weights_fname)
-            
+
         if not os.path.isfile(weightsfile) and reuse_weights:
             #prevent error with more recent versions of xesmf
             reuse_weights=False
@@ -239,8 +248,13 @@ def make_regridder_S2S(
     return regridder_list
 
 
-def make_regridder_L2S(llres_in, csres_out, weightsdir='.',
-                       reuse_weights=True, sg_params=[1, 170, -90]):
+def make_regridder_L2S(
+        llres_in,
+        csres_out,
+        weightsdir='.',
+        reuse_weights=True,
+        sg_params=[1, 170, -90]
+):
     """
     Create an xESMF regridder from a lat/lon to a cubed-sphere grid
 
@@ -309,9 +323,15 @@ def make_regridder_L2S(llres_in, csres_out, weightsdir='.',
 
 
 def create_regridders(
-        refds, devds, weightsdir='.', reuse_weights=True, cmpres=None,
-        zm=False, sg_ref_params=[1, 170, -90],
-        sg_dev_params=[1, 170, -90]):
+        refds,
+        devds,
+        weightsdir='.',
+        reuse_weights=True,
+        cmpres=None,
+        zm=False,
+        sg_ref_params=[1, 170, -90],
+        sg_dev_params=[1, 170, -90]
+):
     """
     Internal function used for creating regridders between two datasets.
     Follows decision logic needed for plotting functions.
@@ -328,19 +348,22 @@ def create_regridders(
             Directory in which to create xESMF regridder NetCDF files
             Default value: '.'
         reuse_weights: bool
-            Set this flag to True to reuse existing xESMF regridder NetCDF files
-            Default value: False
+            Set this flag to True to reuse existing xESMF regridder
+            NetCDF files.  Default value: False
         cmpres: int or str
-            Specific target resolution for comparison grid used in difference and ratio plots
-            Default value: None (will follow logic chain below)
+            Specific target resolution for comparison grid used in
+            difference and ratio plots.  Default value: None (will
+            follow logic chain below)
         zm: bool
-            Set this flag to True if regridders will be used in zonal mean plotting
-            Default value: False
-        sg_ref_params: list[float, float, float] (stretch_factor, target_longitude, target_latitude)
+            Set this flag to True if regridders will be used in zonal mean
+            plotting.  Default value: False
+        sg_ref_params: list[float, float, float]
+            (stretch_factor, target_longitude, target_latitude)
             Ref grid stretched-grid parameters in the format
             [stretch_factor, target_longitude, target_latitude].
             Default value: [1, 170, -90] (no stretching)
-        sg_dev_params: list[float, float, float] (stretch_factor, target_longitude, target_latitude)
+        sg_dev_params: list[float, float, float]
+            (stretch_factor, target_longitude, target_latitude)
             Dev grid stretched-grid parameters in the format
             [stretch_factor, target_longitude, target_latitude].
             Default value: [1, 170, -90] (no stretching)
@@ -359,8 +382,9 @@ def create_regridders(
                  Regridder object between refgrid or devgrid and cmpgrid
                  (will be None if input grid is not lat/lon)
             refregridder_list, devregridder_list: list[6 xESMF regridders]
-                 List of regridder objects for each face between refgrid or devgrid and cmpgrid
-                 (will be None if input grid is not cubed-sphere)
+                 List of regridder objects for each face between refgrid
+                 or devgrid and cmpgrid (will be None if input grid is
+                 not cubed-sphere)
     """
 
     # Take two lat/lon or cubed-sphere xarray datasets and regrid them if
@@ -682,13 +706,18 @@ def regrid_comparison_data(
             new_data = reformat_dims(
                 new_data, format=data_format, towards_common=False)
             return new_data
-    else:
-        return data
+
+    return data
 
 
-def reformat_dims(ds, format, towards_common):
+def reformat_dims(
+        ds,
+        format,
+        towards_common
+):
     """
-    Reformat dimensions of a cubed-sphere / stretched-grid grid between different GCHP formats
+    Reformat dimensions of a cubed-sphere / stretched-grid grid
+    between different GCHP formats
 
     Args:
         ds: xarray Dataset
@@ -702,7 +731,7 @@ def reformat_dims(ds, format, towards_common):
         ds: xarray Dataset
              Original dataset with reformatted dimensions
     """
-    def unravel_checkpoint_lat(ds_in):
+    def unravel_checkpoint(ds_in):
         if isinstance(ds_in, xr.Dataset):
             cs_res = ds_in.dims['lon']
             assert cs_res == ds_in.dims['lat'] // 6
@@ -713,27 +742,32 @@ def reformat_dims(ds, format, towards_common):
             np.linspace(1, 6, 6),
             np.linspace(1, cs_res, cs_res)
         ])
-        ds_in = ds_in.assign_coords({'lat': mi})
+        ds_in = ds_in.assign_coords({"lat": mi, "lon": mi})
         ds_in = ds_in.unstack('lat')
+        ds_in = ds_in.unstack('lon')
         return ds_in
 
-    def ravel_checkpoint_lat(ds_out):
+    def ravel_checkpoint(ds_out):
+        print(ds_out.dims)
+        print(ds_out.coords)
         if isinstance(ds, xr.Dataset):
             cs_res = ds_out.dims['lon']
         else:
             cs_res = ds_out['lon'].size
         ds_out = ds_out.stack(lat=['lat_level_0', 'lat_level_1'])
+        ds_out = ds_out.stack(lon=['lon_level_0', 'lon_level_1'])
         ds_out = ds_out.assign_coords({
-            'lat': np.linspace(1, 6 * cs_res, 6 * cs_res)
+            'lat': np.linspace(1, 6 * cs_res, 6 * cs_res),
+            'lon': np.linspace(1, cs_res, cs_res)
         })
         return ds_out
 
     dim_formats = {
         'checkpoint': {
-            'unravel': [unravel_checkpoint_lat],
-            'ravel': [ravel_checkpoint_lat],
+            'unravel': [unravel_checkpoint],
+            'ravel': [ravel_checkpoint],
             'rename': {
-                'lon': 'X',
+                'lon_level_1': 'X',
                 'lat_level_0': 'F',
                 'lat_level_1': 'Y',
                 'time': 'T',
@@ -752,6 +786,8 @@ def reformat_dims(ds, format, towards_common):
             'transpose': ('time', 'lev', 'nf', 'Ydim', 'Xdim')
         }
     }
+
+    # %%%% Renaming toward the common format %%%%
     if towards_common:
         # Unravel dimensions
         for unravel_callback in dim_formats[format].get('unravel', []):
@@ -759,29 +795,30 @@ def reformat_dims(ds, format, towards_common):
 
         # Rename dimensions
         ds = ds.rename(dim_formats[format].get('rename', {}))
-
         return ds
-    else:
-        # Reverse rename
-        ds = ds.rename(
-            {v: k for k, v in dim_formats[format].get('rename', {}).items()})
 
-        # Ravel dimensions
-        for ravel_callback in dim_formats[format].get('ravel', []):
-            ds = ravel_callback(ds)
 
-        # Transpose
-        if len(ds.dims) == 5 or (len(ds.dims) == 4 and 'lev' in list(
-                ds.dims) and 'time' in list(ds.dims)):
-            # full dim dataset
-            ds = ds.transpose(*dim_formats[format].get('transpose', []))
-        elif len(ds.dims) == 4:
-            # single time
-            ds = ds.transpose(*dim_formats[format].get('transpose', [])[1:])
-        elif len(ds.dims) == 3:
-            # single level / time
-            ds = ds.transpose(*dim_formats[format].get('transpose', [])[2:])
-        return ds
+    # %%%% Renaming from the common format %%%%
+    # Reverse rename
+    ds = ds.rename(
+        {v: k for k, v in dim_formats[format].get('rename', {}).items()})
+
+    # Ravel dimensions
+    for ravel_callback in dim_formats[format].get('ravel', []):
+        ds = ravel_callback(ds)
+
+    # Transpose
+    if len(ds.dims) == 5 or (len(ds.dims) == 4 and 'lev' in list(
+            ds.dims) and 'time' in list(ds.dims)):
+        # full dim dataset
+        ds = ds.transpose(*dim_formats[format].get('transpose', []))
+    elif len(ds.dims) == 4:
+        # single time
+        ds = ds.transpose(*dim_formats[format].get('transpose', [])[1:])
+    elif len(ds.dims) == 3:
+        # single level / time
+        ds = ds.transpose(*dim_formats[format].get('transpose', [])[2:])
+    return ds
 
 
 def sg_hash(
@@ -797,13 +834,19 @@ def sg_hash(
             cs_res=cs_res).encode()).hexdigest()[
         :7]
 
-def regrid_vertical_datasets(ref, dev, target_grid_choice='ref', ref_vert_params=[[],[]],
-                             dev_vert_params=[[],[]], target_vert_params=[[],[]]):
+def regrid_vertical_datasets(
+        ref,
+        dev,
+        target_grid_choice='ref',
+        ref_vert_params=[[],[]],
+        dev_vert_params=[[],[]],
+        target_vert_params=[[],[]]
+):
     """
-    Perform complete vertical regridding of GEOS-Chem datasets to 
-    the vertical grid of one of the datasets or an entirely different 
+    Perform complete vertical regridding of GEOS-Chem datasets to
+    the vertical grid of one of the datasets or an entirely different
     vertical grid.
-    
+
     Args:
         ref: xarray.Dataset
             First dataset
@@ -814,15 +857,15 @@ def regrid_vertical_datasets(ref, dev, target_grid_choice='ref', ref_vert_params
             unless target_vert_params is provided
             Default value: 'ref'
         ref_vert_params (optional): list(list, list) of list-like types
-            Hybrid grid parameter A in hPa and B (unitless) in [AP, BP] format. 
+            Hybrid grid parameter A in hPa and B (unitless) in [AP, BP] format.
             Needed if ref grid is not 47 or 72 levels
             Default value: [[], []]
         dev_vert_params (optional): list(list, list) of list-like types
-            Hybrid grid parameter A in hPa and B (unitless) in [AP, BP] format. 
+            Hybrid grid parameter A in hPa and B (unitless) in [AP, BP] format.
             Needed if dev grid is not 47 or 72 levels
             Default value: [[], []]
         target_vert_params (optional): list(list, list) of list-like types
-            Hybrid grid parameter A in hPa and B (unitless) in [AP, BP] format. 
+            Hybrid grid parameter A in hPa and B (unitless) in [AP, BP] format.
             Will override target_grid_choice as target grid
             Default value: [[], []]
     Returns:
@@ -835,30 +878,40 @@ def regrid_vertical_datasets(ref, dev, target_grid_choice='ref', ref_vert_params
     # Get mid-point pressure and edge pressures for this grid
     ref_pedge, ref_pmid, _ = get_vert_grid(ref, *ref_vert_params)
     dev_pedge, dev_pmid, _ = get_vert_grid(dev, *dev_vert_params)
-    
+
     new_ref, new_dev = ref, dev
-    
+
     if len(ref_pedge) != len(dev_pedge) or target_vert_params != [[],[]]:
         if target_vert_params != [[],[]]:
             #use a specific target grid for regridding if passed
             target_grid = vert_grid(*target_vert_params)
-            target_pedge, target_pmid = target_grid.p_edge(), target_grid.p_mid()        
+            target_pedge = target_grid.p_edge()
+            target_pmid = target_grid.p_mid()
         elif target_grid_choice == 'ref':
-            target_pedge, target_pmid = ref_pedge, ref_pmid
+            target_pedge = ref_pedge
+            target_pmid = ref_pmid
         else:
-            target_pedge, target_pmid = dev_pedge, dev_pmid
-        
-        def regrid_one_vertical_dataset(ds, ds_pedge, target_pedge, target_pmid):
+            target_pedge = dev_pedge
+            target_pmid = dev_pmid
+
+        def regrid_one_vertical_dataset(
+                ds,
+                ds_pedge,
+                target_pedge,
+                target_pmid
+        ):
             new_ds = ds
             if len(ds_pedge) != len(target_pedge):
                 #regrid all 3D (plus possible time dimension) variables
                 xmat_ds = gen_xmat(ds_pedge, target_pedge)
-                regrid_variables = [v for v in ds.data_vars if (("lat" in ds[v].dims or "Xdim" in ds[v].dims)
-                                                                 and ("lon" in ds[v].dims or "Ydim" in ds[v].dims)
-                                                                 and ("lev" in ds[v].dims))]
+                regrid_variables = [v for v in ds.data_vars if (
+                    ("lat" in ds[v].dims or "Xdim" in ds[v].dims) and \
+                    ("lon" in ds[v].dims or "Ydim" in ds[v].dims) and \
+                    ("lev" in ds[v].dims)
+                )]
                 new_ds = xr.Dataset()
                 #currently drop data vars that have lev but don't also have x and y coordinates
-                for v in (set(ds.data_vars)-set(regrid_variables)): 
+                for v in (set(ds.data_vars)-set(regrid_variables)):
                     if 'lev' not in ds[v].dims:
                         new_ds[v] = ds[v]
                 new_ds.attrs = ds.attrs
@@ -866,15 +919,29 @@ def regrid_vertical_datasets(ref, dev, target_grid_choice='ref', ref_vert_params
                     if "time" in ds[v].dims:
                         new_ds_temp = []
                         for time in range(len(ds[v].time)):
-                            new_ds_v = regrid_vertical(ds[v].isel(time=time), xmat_ds, target_pmid)
+                            new_ds_v = regrid_vertical(
+                                ds[v].isel(time=time),
+                                xmat_ds,
+                                target_pmid
+                            )
                             new_ds_temp.append(new_ds_v.expand_dims("time"))
                         new_ds[v] = xr.concat(new_ds_temp, "time")
                     else:
                         new_ds[v] = regrid_vertical(ds[v], xmat, target_pmid)
             return new_ds
-        
-        new_ref = regrid_one_vertical_dataset(ref, ref_pedge, target_pedge, target_pmid)
-        new_dev = regrid_one_vertical_dataset(dev, dev_pedge, target_pedge, target_pmid)
+
+        new_ref = regrid_one_vertical_dataset(
+            ref,
+            ref_pedge,
+            target_pedge,
+            target_pmid
+        )
+        new_dev = regrid_one_vertical_dataset(
+            dev,
+            dev_pedge,
+            target_pedge,
+            target_pmid
+        )
 
     return new_ref, new_dev
 
@@ -949,7 +1016,8 @@ def regrid_vertical(src_data_3D, xmat_regrid, target_levs=[]):
             new_coords['lons'] = (
                 ('lat', 'lon'), src_data_3D.coords['lons'].data)
         out_data = xr.DataArray(out_data,
-                                dims=tuple([dim for dim in src_data_3D.dims]),
+#                                dims=tuple([dim for dim in src_data_3D.dims]),
+                                dims=tuple(list(src_data_3D.dims)),
                                 coords=new_coords,
                                 attrs=src_data_3D.attrs)
 
@@ -997,7 +1065,6 @@ def gen_xmat(p_edge_from, p_edge_to):
         while p_edge_to[i_to + 1] > p_edge_from[0]:
             i_to += 1
 
-    frac_to_total = 0.0
 
     i_weight = 0
     for i_from in range(first_from, n_from):
@@ -1007,7 +1074,6 @@ def gen_xmat(p_edge_from, p_edge_to):
         # Climb the "to" pressures until you intersect with this box
         while i_to < n_to and p_base_from <= p_edge_to[i_to + 1]:
             i_to += 1
-            frac_to_total = 0.0
 
         # Now, loop over output layers as long as there is any overlap,
         # i.e. as long as the base of the "to" layer is below the


### PR DESCRIPTION
This PR fixes several issues with GCPy's online regridding program using xESMF in GCPy module `gcpy/file_regrid.py`.   Several utility functions have been added to the `gcpy/grid.py`, `gcpy/regrid.py`, and `gcpy/cstools.py` modules.

NOTE: At this point, regridding between restart files has been tested.  There are some issues with diagnostic regridding (involving the ordering of vertical levels not being consistent with the `lev:positive` attribute, see: https://github.com/geoschem/GCHP/issues/21).  We do not recommend regridding between GCHP diagnostic files.

### Regridding 4x5 GCClassic to 2x2.5 GCClassic
NOTE: The grayscale came in when converting from PDF to PNG.  Not sure why.
![classic-to-classic sfc](https://github.com/geoschem/gcpy/assets/5880296/39c3c568-245c-4585-a7a1-02b0d1d4e03e)

### Regridding C24 checkpoint to 4x5 GCClassic
![checkpoint-to-classic sfc](https://github.com/geoschem/gcpy/assets/5880296/5c280f4e-6038-4db6-a910-922b3223d109)

### Regridding 4x5 GCClassic to C24 checkpoint
![classic-to-checkpoint sfc](https://github.com/geoschem/gcpy/assets/5880296/790a0b3b-d319-4e27-897f-51bfc7d59bad)

### Regridding C48 checkpoint to C24 checkpoint
![checkpoint-to-checkpoint sfc](https://github.com/geoschem/gcpy/assets/5880296/f8f9d78d-0d75-4cc2-8d69-9989ad11c970)

### Regridding C48 checkpoint to C24 stretched grid
@lizziel: Not sure if the regridding is wrong or the plotting is wrong
![checkpoint-to-stretched sfc](https://github.com/geoschem/gcpy/assets/5880296/57a092dc-93d1-4282-b472-b79e401d8cb5)