### PR TITLE
Fix several issues in file regridding; Also prevent double-flipping of vertical indices

### DIFF
--- a/gcpy/benchmark_funcs.py
+++ b/gcpy/benchmark_funcs.py
@@ -3016,13 +3016,11 @@ def make_benchmark_mass_tables(
     # Update GCHP restart dataset (if any)
     # ==================================================================
 
-    # Ref
-    if any(v.startswith("SPC_") for v in refds.data_vars.keys()):
-        refds = util.rename_and_flip_gchp_rst_vars(refds)
-
-    # Dev
-    if any(v.startswith("SPC_") for v in devds.data_vars.keys()):
-        devds = util.rename_and_flip_gchp_rst_vars(devds)
+    # If the data is from a GCHP restart file, rename variables and
+    # flip levels to match the GEOS-Chem Classic naming and level
+    # conventions.  Otherwise no changes will be made.
+    refds = util.rename_and_flip_gchp_rst_vars(refds)
+    devds = util.rename_and_flip_gchp_rst_vars(devds)
 
     # ==================================================================
     # Make sure that all necessary meteorological variables are found
@@ -3288,17 +3286,13 @@ def make_benchmark_mass_accumulation_tables(
     # Update GCHP restart dataset if needed
     # ==================================================================
 
-    # Ref
-    if any(v.startswith("SPC_") for v in refSds.data_vars.keys()):
-        refSds = util.rename_and_flip_gchp_rst_vars(refSds)
-    if any(v.startswith("SPC_") for v in refEds.data_vars.keys()):
-        refEds = util.rename_and_flip_gchp_rst_vars(refEds)
-
-    # Dev
-    if any(v.startswith("SPC_") for v in devSds.data_vars.keys()):
-        devSds = util.rename_and_flip_gchp_rst_vars(devSds)
-    if any(v.startswith("SPC_") for v in devEds.data_vars.keys()):
-        devEds = util.rename_and_flip_gchp_rst_vars(devEds)
+    # If the data is from a GCHP restart file, rename variables and
+    # flip levels to match the GEOS-Chem Classic naming and level
+    # conventions.  Otherwise no changes will be made.
+    refSds = util.rename_and_flip_gchp_rst_vars(refSds)
+    refEds = util.rename_and_flip_gchp_rst_vars(refEds)
+    devSds = util.rename_and_flip_gchp_rst_vars(devSds)
+    devEds = util.rename_and_flip_gchp_rst_vars(devEds)
 
     # Add area to start restart dataset if area in end but not start
     # Need to consider area variable names used in both GC-Classic and GCHP

--- a/gcpy/examples/diagnostics/compare_diags.py
+++ b/gcpy/examples/diagnostics/compare_diags.py
@@ -97,7 +97,9 @@ def read_data(config):
         msg = "Error reading " + dev_file
         raise Exception(msg) from exc
 
-    # Special handling for GCHP restart files
+    # If the data is from a GCHP restart file, rename variables and
+    # flip levels to match the GEOS-Chem Classic naming and level
+    # conventions.  Otherwise no changes will be made.
     refdata = util.rename_and_flip_gchp_rst_vars(refdata)
     devdata = util.rename_and_flip_gchp_rst_vars(devdata)
 
@@ -261,6 +263,14 @@ def compare_data(config, data):
         varlist_level = [v for v in varlist_level if v in restrict_vars]
         varlist_zonal = [v for v in varlist_zonal if v in restrict_vars]
 
+    # Determine if we need to flip levels in the vertical
+    flip_ref = False
+    flip_dev = False
+    if "flip_levels" in config["data"]["ref"]:
+        flip_ref = config["data"]["ref"]["flip_levels"]
+    if "flip_levels" in config["data"]["dev"]:
+        flip_dev = config["data"]["dev"]["flip_levels"]        
+        
     # ==================================================================
     # Generate the single level comparison plot
     # ==================================================================
@@ -275,6 +285,8 @@ def compare_data(config, data):
             config["data"]["ref"]["label"],
             devdata,
             config["data"]["dev"]["label"],
+            flip_ref=flip_ref,
+            flip_dev=flip_dev,
             ilev=config["options"]["level_plot"]["level_to_plot"],
             varlist=varlist_level,
             pdfname=pdfname,
@@ -296,6 +308,8 @@ def compare_data(config, data):
             config["data"]["ref"]["label"],
             devdata,
             config["data"]["dev"]["label"],
+            flip_ref=flip_ref,
+            flip_dev=flip_dev,
             varlist=varlist_zonal,
             pdfname=pdfname,
             weightsdir=config["paths"]["weights_dir"],

--- a/gcpy/examples/plotting/plot_comparisons.py
+++ b/gcpy/examples/plotting/plot_comparisons.py
@@ -54,7 +54,9 @@ def plot_comparisons(
         drop_variables=skip_these_vars
     )
 
-    # Special handling is needed for GCHP restart files
+    # If the data is from a GCHP restart file, rename variables and
+    # flip levels to match the GEOS-Chem Classic naming and level
+    # conventions.  Otherwise no changes will be made.
     ref_ds = rename_and_flip_gchp_rst_vars(ref_ds)
     dev_ds = rename_and_flip_gchp_rst_vars(dev_ds)
 

--- a/gcpy/examples/plotting/plot_single_panel.py
+++ b/gcpy/examples/plotting/plot_single_panel.py
@@ -39,8 +39,11 @@ def plot_single_panel(infile, varname, level):
     # xarray allows us to read in any NetCDF file
     dset = xr.open_dataset(infile)
 
-    # Special handling if the file is a GCHP restart file
-    dset = rename_and_flip_gchp_rst_vars(dset)
+    # If the data is from a GCHP restart file, rename variables and
+    # flip levels to match the GEOS-Chem Classic naming and level
+    # conventions.  Otherwise no changes will be made.
+    ref_ds = rename_and_flip_gchp_rst_vars(ref_ds)
+    dev_ds = rename_and_flip_gchp_rst_vars(dev_ds)
 
     # You can easily view the variables available for plotting
     # using xarray.  Each of these variables has its own xarray

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -98,6 +98,19 @@ def file_regrid(
     if sg_params_out is None:
         sg_params_out = [1.0, 170.0, -90.0]
 
+    # ------------------------------------------------------------------
+    # There still seem to be a few issues with regridding to cubed-
+    # sphere stretched grids.  For time time being, stop with error
+    # if sg_params_in or sg_params_out do not equal the defaults.
+    #  -- Bob Yantosca & Lizzie Lundgren (24 Oct 2023)
+    if not np.array_equal(sg_params_in, [1.0, 170.0, -90.0]) or \
+       not np.array_equal(sg_params_out, [1.0, 170.0, -90.0]):
+       msg = "Regridding to or from cubed-sphere stretched grids is\n" + \
+           "currently not supported.  Please use the offline regridding\n" + \
+           "method described in the Regridding section of gcpy.readthedocs.io."
+       raise RuntimeError(msg)
+    # ------------------------------------------------------------------
+
     # Load dataset
     dset = xr.open_dataset(
         filein,
@@ -317,7 +330,7 @@ def regrid_cssg_to_cssg(
     """
     if verbose:
         print("file_regrid.py: Regridding from CS/SG to CS/SG")
-
+        
     # Keep all xarray attributes
     with xr.set_options(keep_attrs=True):
 

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -629,14 +629,6 @@ def regrid_ll_to_cssg(
             towards_common=False
         )
 
-        # Flip vertical levels (if necessary) and
-        # set the lev:positive attribute accordingly
-        dset = flip_lev_coord_if_necessary(
-            dset,
-            dim_format_in="classic",
-            dim_format_out=dim_format_out
-        )
-
         # Fix names and attributes of of coordinate variables depending
         # on the format of the ouptut grid (checkpoint or diagnostic).
         # Also convert the "diagnostic" grid to the "checkpoint" grid

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -1331,11 +1331,6 @@ def reshape_cssg_diag_to_chkpt(
         # We then have to unpack that into a linear list that
         # ranges from 1..nf*ydim.
         # ==============================================================
-        print(dset.dims)
-        print(dset.dims["nf"])
-        print(dset.dims["Ydim"])
-        print(dset.Ydim)
-        print(ydim)
         if "nf" in dset.dims and "Ydim" in dset.dims:
             dset = dset.stack(lat=("nf", "Ydim"))
             multi_index_list = dset.lat.values

--- a/gcpy/regrid_restart_file.py
+++ b/gcpy/regrid_restart_file.py
@@ -533,8 +533,6 @@ def regrid_restart_file(
                 "Error when processing your stretched-grid parameters - are they correct?"
             ) from exception
 
-    dataset = check_lev_attribute(output_is_gchp)
-
     dataset.to_netcdf("new_restart_file.nc")
 
     info_message = "Wrote 'new_restart_file.nc' with %d variables"

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -11,6 +11,7 @@ import numpy as np
 import xarray as xr
 from pypdf import PdfWriter, PdfReader
 from gcpy.constants import ENCODING, TABLE_WIDTH
+from gcpy.cstools import is_cubed_sphere_rst_grid
 
 # ======================================================================
 # %%%%% METHODS %%%%%
@@ -807,32 +808,48 @@ def rename_and_flip_gchp_rst_vars(
         dset
 ):
     '''
-    Transforms a GCHP restart dataset to match GCC names and level convention
+    Transforms a GCHP restart dataset to match GCClassic names
+    and level conventions.
 
     Args:
         dset: xarray Dataset
-            Dataset containing GCHP restart file data, such as variables
-            SPC_{species}, BXHEIGHT, DELP_DRY, and TropLev, with level
-            convention down (level 0 is top-of-atmosphere).
+            The input dataset.
 
     Returns:
         dset: xarray Dataset
-            Dataset containing GCHP restart file data with names and level
-            convention matching GCC restart. Variables include
-            SpeciesRst_{species}, Met_BXHEIGHT, Met_DELPDRY, and Met_TropLev,
-            with level convention up (level 0 is surface).
+            If the input dataset is from a GCHP restart file, then
+            dset will contain the original data with variables renamed
+            to match the GEOS-Chem Classic naming conventions, and
+            with levels indexed as lev:positive="up".  Otherwise, the
+            original data will be returned.
     '''
+    verify_variable_type(dset, xr.Dataset)
+
+    # Return if this dataset is not from a GCHP checkpoint/restart file
+    if not is_cubed_sphere_rst_grid(dset):
+        return dset
+
+    # Create dictionary of variable name replacements
     for var in dset.data_vars.keys():
-        if var.startswith('SPC_'):
+        # TODO: Think of better algorithm in case we ever change
+        # the internal state to start with something else than "SPC_".
+        if var.startswith("SPC_"):
             spc = var.replace('SPC_', '')
-            dset = dset.rename({var: 'SpeciesRst_' + spc})
-        elif var == 'DELP_DRY':
-            dset = dset.rename({"DELP_DRY": "Met_DELPDRY"})
-        elif var == 'BXHEIGHT':
-            dset = dset.rename({"BXHEIGHT": "Met_BXHEIGHT"})
-        elif var == 'TropLev':
-            dset = dset.rename({"TropLev": "Met_TropLev"})
+            old_to_new[var] = 'SpeciesRst_' + spc
+        if var == "DELP_DRY":
+            old_to_new["DELP_DRY"] = "Met_DELPDRY"
+        if var == "BXHEIGHT":
+            old_to_new["BXHEIGHT"] = "Met_BXHEIGHT"
+        if var == "TropLev":
+            old_to_new["TropLev"] = "Met_TropLev"
+
+    # Replace variable names in one operation
+    dset = dset.rename(old_to_new)
+
+    # Flip levels
     dset = dset.sortby('lev', ascending=False)
+    dset.lev.attrs["positive"] = "up"
+
     return dset
 
 

--- a/gcpy/util.py
+++ b/gcpy/util.py
@@ -830,6 +830,7 @@ def rename_and_flip_gchp_rst_vars(
         return dset
 
     # Create dictionary of variable name replacements
+    old_to_new = {}
     for var in dset.data_vars.keys():
         # TODO: Think of better algorithm in case we ever change
         # the internal state to start with something else than "SPC_".


### PR DESCRIPTION
## Overview
This PR fixes several remaining issues with GCPy file regridding using online weights.

1. Routine `rename_and_flip_gchp_rst_vars.py` now uses inquiry function `is_cubed_sphere_rst_grid` internally.  If the data is on the GCHP checkpoint/restart grid, then data variables will be renamed according to GCHP conventions and vertical levels will be flipped so that it is positive down.  Otherwise the original data will be returned unchanged.  This was necessary to prevent a bug in which vertical levels were flipped twice in  `compare_diags.py` and the example plotting scripts `plot_comparisons.py` and `plot_single_level.py`.

2. Added the boolean argument `gchp_indices` to routines `get_ilev_coords` and `get_lev_coords`.  If true, then the coordinates will be returned as indices (e.g. 1..72), which is used for the GCHP level dimension.

3. Fixed several logic issues in `file_regrid.py`:
  a. Move `flip_lev_coord_if_necessary` so that it occurs before variable renaming/regridding.  This prevents the flipping algorithm from being spoofed by renamed variables.
  b. Renamed `drop_and_rename_classic_variables` to `drop_classic_vars`,  which only drops the non-regriddable variables.
  c. Move variable renaming into `rename_restart_variables`.  Also improve logic so that variables are renamed properly
  d. Updated logic in the `flip_lev_coord_if_necessary` routine.  Also make sure to save coordinates in the proper order.  GCHP level coordinates are now saved as indices.

4. Fixed issues with command-line arguments:
  a. Renamed Python argument `fin` to `filein`, to match the command-line argument
  b. Renamed Python argument `fout` to `fileout`, to match the command-line argument
  c. Added verbose printout of arguments
  d. Remove `nargs=1` from `weightsdir` and `verbose`, which turns them into a list of 1 element (instead of a scalar, which is what it should be)

Output from `file_regrid.py` is shown below.

TODO: Double-check the `Regridding.rst` instructions to make sure they are consistent with this PR.  Further documentation fixes will be pushed to `docs/dev`.

## Common use cases

###  GCClassic to GCHP checkpoint
![gcc2chk](https://github.com/geoschem/gcpy/assets/5880296/cf5c3f12-6cec-4185-9495-20cd3fb60993)

### GCClassic to GCClassic
![gcc2gcc](https://github.com/geoschem/gcpy/assets/5880296/999f2c01-46d6-42ef-9df5-4904ee59a88a)

### GCHP checkpoint to GCHP checkpoint
![chk2chk](https://github.com/geoschem/gcpy/assets/5880296/9f3cc8cf-a12d-4878-b293-b8195649f6c4)

### GCHP checkpoint to GCHP checkpoint, stretched grid:
NOTE: Not sure if this is a plotting issue or a regridding issue.
![chk2str](https://github.com/geoschem/gcpy/assets/5880296/8ded19dc-8e47-44c0-a6ca-4d49428afedd)

### GCHP checkpoint to GCClassic
![chk2gcc](https://github.com/geoschem/gcpy/assets/5880296/be086cd2-65d4-4caf-93c2-727a77b97223)

## Less common use cases (shown for completeness)
I wanted to show these cases, just to show that the regridding seems to work OK.  Some editing of variable names may still be needed.  In any case, these are not the usual use case so I think it's OK.

### GCHP checkpoint to GCHP diagnostic
![chk2dgn](https://github.com/geoschem/gcpy/assets/5880296/58a249a1-db7c-47a5-a495-e6c3a408a29c)

### GCHP diagnostic to GCHP checkpoint
![dgn2chk](https://github.com/geoschem/gcpy/assets/5880296/a6cbf537-e7d6-4b52-b4b6-20cb5c5a3819)

### GCHP diagnostic to GCHP diagnostic
![dgn2dgn](https://github.com/geoschem/gcpy/assets/5880296/d4d71757-e5ac-478f-8bfe-6fcd12811a2a)

### GCClassic to GCHP diagnostic
![gcc2dgn](https://github.com/geoschem/gcpy/assets/5880296/c5990f41-1c35-4587-addc-60e1f09aede4)

### GCHP diagnostic to GCClassic
![dgn2gcc](https://github.com/geoschem/gcpy/assets/5880296/3ccdd04a-a8fb-44ff-b14a-eb726f811a86)