### PR TITLE
Fix bug preventing comparison plots of ref and dev with different units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `seaborn` plot style names to conform to the latest matplotlib
 - Set `lev:positive` and/or `ilev:positive` properly in `regrid_restart_file.py` and `file_regrid.py`
 - Prevent overwriting of `lev` coord in `file_regrid.py` at netCDF write time
+- Fixed bug in option to allow different units when making comparison plots
 
 ### Removed
 - Removed `gchp_is_pre_13_1` arguments & code from benchmarking routines

--- a/gcpy/plot/compare_single_level.py
+++ b/gcpy/plot/compare_single_level.py
@@ -384,11 +384,9 @@ def compare_single_level(
         if ds_devs[i].units.strip() == "UNITLESS":
             ds_devs[i].attrs["units"] = "1"
 
-        # Check that units are the same in ref and dev. Will exit with
-        # an error if do not match and enforce_units is true (default).
-        if not check_units(ds_refs[i], ds_devs[i]) and enforce_units:
-            raise ValueError(
-                'Units in ref and dev must match when enforce_units is True')
+        # Compare units of ref and dev. The check_units function will throw an
+        # error if units do not match and enforce_units is True.
+        check_units(ds_refs[i], ds_devs[i], enforce_units)
 
         # Convert from ppb to ug/m3 if convert_to_ugm3 is passed as true
         if convert_to_ugm3:

--- a/gcpy/plot/compare_zonal_mean.py
+++ b/gcpy/plot/compare_zonal_mean.py
@@ -416,11 +416,9 @@ def compare_zonal_mean(
         if ds_devs[i].units.strip() == "UNITLESS":
             ds_devs[i].attrs["units"] = "1"
 
-        # Check that units are the same in ref and dev. Will exit with
-        # an error if do not match and enforce_units is true (default).
-        if not check_units(ds_refs[i], ds_devs[i]) and enforce_units:
-            raise ValueError(
-                'Units in ref and dev must match when enforce_units is True')
+        # Compare units of ref and dev. The check_units function will throw an error
+        # if the units do not match and enforce_units is True.
+        check_units(ds_refs[i], ds_devs[i], enforce_units)
 
         # Convert from ppb to ug/m3 if convert_to_ugm3 is passed as true
         if convert_to_ugm3:


### PR DESCRIPTION
Name: Lizzie Lundgren
Institution: Harvard University

I was comparing raw and processed met-fields and noticed that I could not create comparison plots if the units did not match. This was despite passing `enforce_units=False` to the `compare_single_level` function. This PR fixes this problem.