### PR TITLE
Now let user specify X11 backend with "export MPLBACKEND="tkagg" (or "MacOSX")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated and cleaned up code in `gcpy/regrid.py`
 - Example scripts`plot_single_level` and `plot_comparisons` can now accept command-line arguments
 - Example scripts `plot_single_level.py`, `plot_comparisons.py`, `compare_diags.py` now handle GCHP restart files properly
+- Now specify the X11 backend with by setting the `MPLBACKEND` environment variable
 
 ### Fixed
 - Generalized test for GCHP or GCClassic restart file in `regrid_restart_file.py`

--- a/gcpy/examples/plotting/plot_comparisons.py
+++ b/gcpy/examples/plotting/plot_comparisons.py
@@ -11,11 +11,21 @@ points in one run that are stored in separate xarray datasets.
 
 The example data described here is in lat/lon format, but the same
 code works equally well for cubed-sphere (GCHP) data.
+
+NOTE: If you are using GCPy from a Mac, set the environment variable:
+
+   export MPLBACKEND="MacOSX"
+
+Otherwise set:
+
+   export MPLBACKEND="tkagg"
+
+This will set the proper X11 backend (which is needed to open a plot
+window on the screen.  There is some incompatibility with the Tck/Tk
+backend "tkagg" in MacOS X operating systems.
 """
 import argparse
 import xarray as xr
-from matplotlib import use as mpl_use
-mpl_use("tkagg")                          # X11 backend for plt.show()
 import matplotlib.pyplot as plt
 from gcpy.constants import skip_these_vars
 from gcpy.plot.compare_single_level import compare_single_level

--- a/gcpy/examples/plotting/plot_single_panel.py
+++ b/gcpy/examples/plotting/plot_single_panel.py
@@ -12,11 +12,21 @@ works equally well for cubed-sphere (GCHP) data.
 For full documentation on the plotting capabilities of GCPy
 (including full argument lists), please see the GCPy documentation
 at https://gcpy.readthedocs.io.
+
+NOTE: If you are using GCPy from a Mac, set the environment variable:
+
+   export MPLBACKEND="MacOSX"
+
+Otherwise set:
+
+   export MPLBACKEND="tkagg"
+
+This will set the proper X11 backend (which is needed to open a plot
+window on the screen.  There is some incompatibility with the Tck/Tk
+backend "tkagg" in MacOS X operating systems.
 """
 import argparse
 import xarray as xr
-from matplotlib import use as mpl_use
-mpl_use("tkagg")                        # X11 backend for plt.show()
 import matplotlib.pyplot as plt
 from gcpy.plot.single_panel import single_panel
 from gcpy.util import rename_and_flip_gchp_rst_vars
@@ -40,8 +50,7 @@ def plot_single_panel(infile, varname, level):
     # If the data is from a GCHP restart file, rename variables and
     # flip levels to match the GEOS-Chem Classic naming and level
     # conventions.  Otherwise no changes will be made.
-    ref_ds = rename_and_flip_gchp_rst_vars(ref_ds)
-    dev_ds = rename_and_flip_gchp_rst_vars(dev_ds)
+    dset = rename_and_flip_gchp_rst_vars(dset)
 
     # You can easily view the variables available for plotting
     # using xarray.  Each of these variables has its own xarray


### PR DESCRIPTION
This is the companion PR for issue #269.  In example scripts `gcpy/examples/plotting/plot_single_panel.py` and `gcpy/examples/plotting/plot_comparisons.py`, we had set the X11 backend for Matplotib to `tkagg` (from the Tcl/Tk library).  The X11 backend is necessary so that these example scripts can open a plot window on the screen.

However, the `tkagg` backend is not compatible on MacOSX.  Therefore, rather than hardcoding a value for the X11 backend, we will let the user pick the proper value by setting either:
```bash
export MPLBACKEND="tkagg"        
or
export MPLBACKEND="MacOSX" 
```