### PR TITLE
Bug fix: Use proper default value for weightsdir in file_regrid.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Now use the proper default value for the `--weightsdir` argument to `gcpy/file_regrid.py`
+
 ## [1.4.0] - 2023-11-20
 ### Added
 - Added C2H2 and C2H4 to `emission_species.yml`

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -1540,7 +1540,7 @@ def main():
         "-w", "--weightsdir",
         metavar="WGT",
         type=str,
-        default="",
+        default=".",
         help="Directory where regridding weights are found (or will be created)"
     )
     args = parser.parse_args()

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -1540,7 +1540,7 @@ def main():
         "-w", "--weightsdir",
         metavar="WGT",
         type=str,
-        default=False,
+        default="",
         help="Directory where regridding weights are found (or will be created)"
     )
     args = parser.parse_args()


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x [Contributing guidelines](https://gcpy.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to #278.  The proper default value for the `--weightsdir` argument to `gcpy/file_regrid.py` is now used.  This had been `False` but it should have been `"."`.

### Expected changes

This will prevent a `TypeError` when the `--weightsdir` argument is not passed to `file_regrid.py`.

### Related Github Issue(s)

- Closes #278 
