### PR TITLE
Add option to create drydep velocity plots from benchmark output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- YAML tag `operations_budget` is now `ops_budget_table` in `gcpy/benchmark/config/1yr_tt_benchmark.yml`
+
 ## [1.4.0] - 2023-11-20
 ### Added
 - Added C2H2 and C2H4 to `emission_species.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to GCPy will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Script `gcpy/benchmark/modules/benchmark_utils.py`, with common benchmark utility functions
+- Script `gcpy/benchmark/modules/benchmark_drydep.py`, with code to create drydep velocity plots
+- YAML tag `plot_drydep` in `gcpy/benchmark/config/*.yml` files
+
 ### Changed
 - YAML tag `operations_budget` is now `ops_budget_table` in `gcpy/benchmark/config/1yr_tt_benchmark.yml`
 

--- a/gcpy/benchmark/cloud/template.1hr_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1hr_benchmark.yml
@@ -110,6 +110,7 @@ options:
     plot_emis: False
     emis_table: True
     plot_jvalues: False
+    plot_drydep: False
     plot_aod: False
     mass_table: True
     mass_accum_table: False

--- a/gcpy/benchmark/cloud/template.1mo_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1mo_benchmark.yml
@@ -111,6 +111,7 @@ options:
     emis_table: True
     plot_jvalues: True
     plot_aod: True
+    plot_drydep: True
     mass_table: True
     mass_accum_table: False
     ops_budget_table: False

--- a/gcpy/benchmark/cloud/template.1mo_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1mo_benchmark.yml
@@ -111,7 +111,7 @@ options:
     emis_table: True
     plot_jvalues: True
     plot_aod: True
-    plot_drydep: True
+    plot_drydep: False  # Need to save out DryDep collection for 1-mo
     mass_table: True
     mass_accum_table: False
     ops_budget_table: False

--- a/gcpy/benchmark/config/1mo_benchmark.yml
+++ b/gcpy/benchmark/config/1mo_benchmark.yml
@@ -111,6 +111,7 @@ options:
     emis_table: True
     plot_jvalues: True
     plot_aod: True
+    plot_drydep: True
     mass_table: True
     mass_accum_table: False
     ops_budget_table: False

--- a/gcpy/benchmark/config/1mo_benchmark.yml
+++ b/gcpy/benchmark/config/1mo_benchmark.yml
@@ -111,7 +111,7 @@ options:
     emis_table: True
     plot_jvalues: True
     plot_aod: True
-    plot_drydep: True
+    plot_drydep: False  # Need to save out DryDep collection for 1-mo
     mass_table: True
     mass_accum_table: False
     ops_budget_table: False

--- a/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
@@ -113,6 +113,7 @@ options:
     emis_table: True
     plot_jvalues: True
     plot_aod: True
+    plot_drydep: True
     mass_table: True
     ops_budget_table: False
     aer_budget_table: True

--- a/gcpy/benchmark/config/1yr_tt_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_tt_benchmark.yml
@@ -111,7 +111,7 @@ options:
     plot_wetdep: True
     plot_drydep: True
     rnpbbe_budget: True
-    operations_budget: False
+    ops_budget_table: False
     mass_table: True
     ste_table: True
     cons_table: True

--- a/gcpy/benchmark/config/1yr_tt_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_tt_benchmark.yml
@@ -1,3 +1,4 @@
+
 ---
 # =====================================================================
 # Benchmark configuration file (**EDIT AS NEEDED**)
@@ -108,6 +109,7 @@ options:
   outputs:
     plot_conc: True
     plot_wetdep: True
+    plot_drydep: True
     rnpbbe_budget: True
     operations_budget: False
     mass_table: True

--- a/gcpy/benchmark/modules/benchmark_drydep.py
+++ b/gcpy/benchmark/modules/benchmark_drydep.py
@@ -28,6 +28,7 @@ def make_benchmark_drydep_plots(
         sigdiff_files=None,
         n_job=-1,
         time_mean=False,
+        varlist=None,
         spcdb_dir=os.path.join(os.path.dirname(__file__), "..", "..")
 ):
     """
@@ -83,6 +84,9 @@ def make_benchmark_drydep_plots(
         time_mean : bool
             Determines if we should average the datasets over time
             Default value: False
+        varlist: list of str
+            List of variables to plot.  If varlist is None, then
+            all common variables in Ref & Dev will be plotted.
     """
 
     # Create directory for plots (if it doesn't exist)
@@ -101,12 +105,13 @@ def make_benchmark_drydep_plots(
     )
 
     # Get common variables between Ref and Dev
-    varlist = bmk_util.get_common_varnames(
-        refdata,
-        devdata,
-        prefix="DryDepVel_",
-        verbose=verbose
-    )
+    if varlist is None:
+        varlist = bmk_util.get_common_varnames(
+            refdata,
+            devdata,
+            prefix="DryDepVel_",
+            verbose=verbose
+        )
 
     # Create surface plots
     sigdiff_list = []
@@ -153,3 +158,18 @@ def make_benchmark_drydep_plots(
     del refdata
     del devdata
     gc.collect()
+
+
+def drydepvel_species():
+    """
+    Returns a list of species for the dry deposition velocity
+    (DryDepVel) benchmark plots:
+
+    Returns:
+    --------
+    varnames (list of str): Variable names to plot
+    """
+    # These are key dry deposition species (as per Mat Evans)
+    return ["DryDepVel_ACET", "DryDepVel_HNO3", "DryDepVel_NH3",
+            "DryDepVel_NH4", "DryDepVel_NIT", "DryDepVel_NITs",
+            "DryDepVel_O3", "DryDepVel_SO4"]

--- a/gcpy/benchmark/modules/benchmark_drydep.py
+++ b/gcpy/benchmark/modules/benchmark_drydep.py
@@ -5,9 +5,7 @@ import os
 import gc
 import numpy as np
 from gcpy import util
-from gcpy.constants import skip_these_vars
 from gcpy.plot.compare_single_level import compare_single_level
-from gcpy.plot.compare_zonal_mean import compare_zonal_mean
 import gcpy.benchmark.modules.benchmark_utils as bmk_util
 
 # Suppress numpy divide by zero warnings to prevent output spam
@@ -19,18 +17,18 @@ def make_benchmark_drydep_plots(
         refstr,
         dev,
         devstr,
-        collection,
+        collection="DryDep",
         dst="./benchmark",
+        subdst=None,
         cmpres=None,
-        datestr=None,
         overwrite=False,
         verbose=False,
         log_color_scale=False,
-        weightsdir=".".
+        weightsdir=".",
+        sigdiff_files=None,
         n_job=-1,
         time_mean=False,
-        spcdb_dir=None,
-        var_prefix="DryDepVel"
+        spcdb_dir=os.path.join(os.path.dirname(__file__), "..", "..")
 ):
     """
     Creates six-panel comparison plots (PDF format) from GEOS-Chem
@@ -48,18 +46,20 @@ def make_benchmark_drydep_plots(
             data set.
         devstr: str
             A string to describe dev (e.g. version number)
-        collection: str
-            String name of collection to plot comparisons for.
 
     Keyword Args (optional):
+        collection : str
+            Name of the diagnostic collection (e.g. "DryDep")
         dst: str
             A string denoting the destination folder where a PDF
             file containing plots will be written.
             Default value: ./benchmark
-        datestr: str
-            A string with date information to be included in both the
-            plot pdf filename and as a destination folder subdirectory
-            for writing plots
+        subdst: str
+            A string denoting the sub-directory of dst where PDF
+            files containing plots will be written.  In practice,
+            subdst is only needed for the 1-year benchmark output,
+            and denotes a date string (such as "Jan2016") that
+            corresponds to the month that is being plotted.
             Default value: None
         benchmark_type: str
             A string denoting the type of benchmark output to plot, options are
@@ -72,13 +72,6 @@ def make_benchmark_drydep_plots(
         verbose: bool
             Set this flag to True to print extra informational output.
             Default value: False.
-        plots: list of strings
-            List of plot types to create.
-            Default value: ['sfc', '500hpa', 'zonalmean']
-        normalize_by_area: bool
-            Set this flag to true to enable normalization of data
-            by surfacea area (i.e. kg s-1 --> kg s-1 m-2).
-            Default value: False
         n_job: int
             Defines the number of simultaneous workers for parallel plotting.
             Set to 1 to disable parallel plotting. Value of -1 allows the
@@ -90,58 +83,51 @@ def make_benchmark_drydep_plots(
         time_mean : bool
             Determines if we should average the datasets over time
             Default value: False
-        var_prefix : str
-            If 
     """
 
-    # Create destination plot directory
-    bmk_util.make_directory(dst, overwrite)
-    target_dst = bmk_util.make_collection_subdir(dst, collection, datestr)
-
-    # Defaults for arguments
-    if plots is None:
-        plots = ["sfc", "500hpa", "zonalmean"]
-    if spcdb_dir is None:
-        spcdb_dir = os.path.join(os.path.dirname(__file__), "..", "..")
+    # Create directory for plots (if it doesn't exist)
+    dst = bmk_util.make_output_dir(
+        dst,
+        collection,
+        subdst,
+        overwrite=overwrite,
+    )
 
     # Read data
-    refds, devds = bmk.util_read_ref_and_dev(ref, dev, time_mean)
-    if refmet is not None and devmet is not None:
-        refmetds, devmetds = bmk_util.read_ref_and_dev(ref, dev, time_mean)
-
-    # Make sure that Ref and Dev datasets have the same variables.
-    # Variables that are in Ref but not in Dev will be added to Dev
-    # with all missing values (NaNs). And vice-versa.
-    # Turn this off for now since add_missing_variables inserts GCC area into
-    # GCHP files, which causes problems with area normalization (ewl)
-    #[refds, devds] = add_missing_variables(refds, devds)
+    refdata, devdata = bmk_util.read_ref_and_dev(
+        ref,
+        dev,
+        time_mean=time_mean
+    )
 
     # Get common variables between Ref and Dev
     varlist = bmk_util.get_common_varnames(
-        refds, 
-        devds, 
-        var_prefix=var_prefix
+        refdata,
+        devdata,
+        prefix="DryDepVel_",
         verbose=verbose
     )
-        
-    # Surface plots
-    plotfilename = f"{collection}_Surface.pdf"
-    if datestr is not None:
-        plotfilename = f"{collection}_Surface_{datestr}.pdf"
-    pdfname = os.path.join(target_dst, plotfilename)
+
+    # Create surface plots
+    sigdiff_list = []
+    pdfname = bmk_util.pdf_filename(
+        dst,
+        collection,
+        subdst,
+        plot_type="Surface"
+    )
     compare_single_level(
-        refds,
+        refdata,
         refstr,
-        devds,
+        devdata,
         devstr,
         varlist=varlist,
         cmpres=cmpres,
         ilev=0,
-        refmet=refmetds,
-        devmet=devmetds,
         pdfname=pdfname,
-        normalize_by_area=normalize_by_area,
-        extra_title_txt=datestr,
+        log_color_scale=log_color_scale,
+        extra_title_txt=subdst,
+        sigdiff_list=sigdiff_list,
         weightsdir=weightsdir,
         n_job=n_job,
         spcdb_dir=spcdb_dir
@@ -150,16 +136,20 @@ def make_benchmark_drydep_plots(
         pdfname,
         varlist,
         remove_prefix=collection + '_',
-        verbose=verbose)
-
+        verbose=verbose
     )
 
+    # Write significant differences to file (if there are any)
+    bmk_util.print_sigdiffs(
+        sigdiff_files,
+        sigdiff_list,
+        diff_type="sfc",
+        diff_title="DryDepVel"
+    )
 
     # -------------------------------------------
     # Clean up
     # -------------------------------------------
-    del refds
-    del devds
-    del refmetds
-    del devmetds
+    del refdata
+    del devdata
     gc.collect()

--- a/gcpy/benchmark/modules/benchmark_drydep.py
+++ b/gcpy/benchmark/modules/benchmark_drydep.py
@@ -1,0 +1,165 @@
+"""
+Specific utilities for creating plots from GEOS-Chem benchmark simulations.
+"""
+import os
+import gc
+import numpy as np
+from gcpy import util
+from gcpy.constants import skip_these_vars
+from gcpy.plot.compare_single_level import compare_single_level
+from gcpy.plot.compare_zonal_mean import compare_zonal_mean
+import gcpy.benchmark.modules.benchmark_utils as bmk_util
+
+# Suppress numpy divide by zero warnings to prevent output spam
+np.seterr(divide="ignore", invalid="ignore")
+
+
+def make_benchmark_drydep_plots(
+        ref,
+        refstr,
+        dev,
+        devstr,
+        collection,
+        dst="./benchmark",
+        cmpres=None,
+        datestr=None,
+        overwrite=False,
+        verbose=False,
+        log_color_scale=False,
+        weightsdir=".".
+        n_job=-1,
+        time_mean=False,
+        spcdb_dir=None,
+        var_prefix="DryDepVel"
+):
+    """
+    Creates six-panel comparison plots (PDF format) from GEOS-Chem
+    benchmark simualtion output.  Can be used with data collections
+    that do not require special handling (e.g. concentrations).
+
+    Args:
+        ref: str
+            Path name for the "Ref" (aka "Reference") data set.
+        refstr: str
+            A string to describe ref (e.g. version number)
+        dev: str
+            Path name for the "Dev" (aka "Development") data set.
+            This data set will be compared against the "Reference"
+            data set.
+        devstr: str
+            A string to describe dev (e.g. version number)
+        collection: str
+            String name of collection to plot comparisons for.
+
+    Keyword Args (optional):
+        dst: str
+            A string denoting the destination folder where a PDF
+            file containing plots will be written.
+            Default value: ./benchmark
+        datestr: str
+            A string with date information to be included in both the
+            plot pdf filename and as a destination folder subdirectory
+            for writing plots
+            Default value: None
+        benchmark_type: str
+            A string denoting the type of benchmark output to plot, options are
+            FullChemBenchmark, TransportTracersBenchmark, or CH4Benchmark.
+            Default value: "FullChemBenchmark"
+        overwrite: bool
+            Set this flag to True to overwrite files in the
+            destination folder (specified by the dst argument).
+            Default value: False.
+        verbose: bool
+            Set this flag to True to print extra informational output.
+            Default value: False.
+        plots: list of strings
+            List of plot types to create.
+            Default value: ['sfc', '500hpa', 'zonalmean']
+        normalize_by_area: bool
+            Set this flag to true to enable normalization of data
+            by surfacea area (i.e. kg s-1 --> kg s-1 m-2).
+            Default value: False
+        n_job: int
+            Defines the number of simultaneous workers for parallel plotting.
+            Set to 1 to disable parallel plotting. Value of -1 allows the
+            application to decide.
+            Default value: -1
+        spcdb_dir: str
+            Directory of species_datbase.yml file
+            Default value: Directory of GCPy code repository
+        time_mean : bool
+            Determines if we should average the datasets over time
+            Default value: False
+        var_prefix : str
+            If 
+    """
+
+    # Create destination plot directory
+    bmk_util.make_directory(dst, overwrite)
+    target_dst = bmk_util.make_collection_subdir(dst, collection, datestr)
+
+    # Defaults for arguments
+    if plots is None:
+        plots = ["sfc", "500hpa", "zonalmean"]
+    if spcdb_dir is None:
+        spcdb_dir = os.path.join(os.path.dirname(__file__), "..", "..")
+
+    # Read data
+    refds, devds = bmk.util_read_ref_and_dev(ref, dev, time_mean)
+    if refmet is not None and devmet is not None:
+        refmetds, devmetds = bmk_util.read_ref_and_dev(ref, dev, time_mean)
+
+    # Make sure that Ref and Dev datasets have the same variables.
+    # Variables that are in Ref but not in Dev will be added to Dev
+    # with all missing values (NaNs). And vice-versa.
+    # Turn this off for now since add_missing_variables inserts GCC area into
+    # GCHP files, which causes problems with area normalization (ewl)
+    #[refds, devds] = add_missing_variables(refds, devds)
+
+    # Get common variables between Ref and Dev
+    varlist = bmk_util.get_common_varnames(
+        refds, 
+        devds, 
+        var_prefix=var_prefix
+        verbose=verbose
+    )
+        
+    # Surface plots
+    plotfilename = f"{collection}_Surface.pdf"
+    if datestr is not None:
+        plotfilename = f"{collection}_Surface_{datestr}.pdf"
+    pdfname = os.path.join(target_dst, plotfilename)
+    compare_single_level(
+        refds,
+        refstr,
+        devds,
+        devstr,
+        varlist=varlist,
+        cmpres=cmpres,
+        ilev=0,
+        refmet=refmetds,
+        devmet=devmetds,
+        pdfname=pdfname,
+        normalize_by_area=normalize_by_area,
+        extra_title_txt=datestr,
+        weightsdir=weightsdir,
+        n_job=n_job,
+        spcdb_dir=spcdb_dir
+    )
+    util.add_bookmarks_to_pdf(
+        pdfname,
+        varlist,
+        remove_prefix=collection + '_',
+        verbose=verbose)
+
+    )
+
+
+    # -------------------------------------------
+    # Clean up
+    # -------------------------------------------
+    del refds
+    del devds
+    del refmetds
+    del devmetds
+    gc.collect()

--- a/gcpy/benchmark/modules/benchmark_drydep.py
+++ b/gcpy/benchmark/modules/benchmark_drydep.py
@@ -143,8 +143,8 @@ def make_benchmark_drydep_plots(
     bmk_util.print_sigdiffs(
         sigdiff_files,
         sigdiff_list,
-        diff_type="sfc",
-        diff_title="DryDepVel"
+        sigdiff_type="sfc",
+        sigdiff_cat="DryDepVel"
     )
 
     # -------------------------------------------

--- a/gcpy/benchmark/modules/benchmark_utils.py
+++ b/gcpy/benchmark/modules/benchmark_utils.py
@@ -1,24 +1,21 @@
 """
-Specific utilities for creating plots from GEOS-Chem benchmark simulations.
-
-TODO: Migrate benchmark-specific utilities from gcpy/benchmark.py to here.
+Utility functions specific to the benchmark plotting/tabling scripts.
+TODO: Migrate other benchmark-specific utilities from gcpy/benchmark.py to here.
 """
 import os
-import gc
 import numpy as np
 from gcpy import util
 from gcpy.constants import skip_these_vars
-from gcpy.plot.compare_single_level import compare_single_level
-from gcpy.plot.compare_zonal_mean import compare_zonal_mean
 
 # Suppress numpy divide by zero warnings to prevent output spam
 np.seterr(divide="ignore", invalid="ignore")
 
 
-def make_collection_subdir(
+def make_output_dir(
         dst,
         collection,
-        datestr
+        subdst,
+        overwrite=False
 ):
     """
     Creates a subdirectory for the given collection type
@@ -26,28 +23,33 @@ def make_collection_subdir(
 
     Args:
     ----
-    dst        (str) : Destination directory
-    collection (str) : Collection name
-    datestr    (str) : Date string
+    dst        (str     ) : Destination directory
+    collection (str|None) : e.g. "Aerosols", "DryDep", "Oxidants", ...
+    subdst     (str     ) : e.g. "AnnualMean", "Apr2019", ...
 
     Returns:
     --------
-    target_dst (str) : Directory that was created
-
+    dst        (str     ) : Path of the directory that was created
     """
+    util.verify_variable_type(dst, str)
+    util.verify_variable_type(collection, str)
+    util.verify_variable_type(subdst, (str, None))
 
-    # Make a collection subdirectory
-    target_dst = os.path.join(dst, collection)
-    if not os.path.isdir(target_dst):
-        os.mkdir(target_dst)
+    # Create the destination folder (if it doesn't exist)
+    util.make_directory(dst, overwrite)
 
-    # If datestr is passed, create a further subdirectory
-    if datestr is not None:
-        target_dst = os.path.join(target_dst, datestr)
-        if not os.path.isdir(target_dst):
-            os.mkdir(target_dst)
+    # Make the dst/collection subdirectory
+    dst = os.path.join(dst, collection)
+    if not os.path.isdir(dst):
+        os.mkdir(dst)
 
-    return target_dst
+    # If necessary, make the dst/collection/subdst subdirectory
+    if subdst is not None:
+        dst = os.path.join(dst, subdst)
+        if not os.path.isdir(dst):
+            os.mkdir(dst)
+
+    return dst
 
 
 def read_ref_and_dev(
@@ -59,48 +61,200 @@ def read_ref_and_dev(
     """
     Reads files from the Ref and Dev models into xarray.Dataset objects.
 
-
     Args:
     -----
-    ref (str or list) : Ref data file(s)
-    def (str or list) : Ref data file(s)
-    time_mean (bool)  : Return the average over the time dimension
+    ref       (str|list  ) : Ref data file(s)
+    def       (str|list  ) : Dev data file(s)
+    time_mean (bool      ) : Return the average over the time dimension?
 
     Returns:
     --------
-    refds (xarray.Dataset) : Data from the Ref model
-    devds (xarray.Dataset) : Data from the Dev model
+    ref_data  (xr.Dataset) : Data from the Ref model
+    dev_data  (xr.Dataset) ls: Data from the Dev model
     """
+    util.verify_variable_type(ref, (str, list))
+    util.verify_variable_type(dev, (str, list))
+    util.verify_variable_type(time_mean, bool)
 
-    # Get the function that will read file(s) into a dataset
+    ref_data = None
+    dev_data = None
     reader = util.dataset_reader(time_mean, verbose=verbose)
 
-    # Open datasets
-    refds = reader(ref, drop_variables=skip_these_vars)
-    devds = reader(dev, drop_variables=skip_these_vars)
+    if ref is not None:
+        ref_data = reader(ref, drop_variables=skip_these_vars)
+        if time_mean:
+            ref_data = util.dataset_mean(ref_data)
 
-    # Take
-    if time_mean:
-        refds = util.dataset_mean(refds)
-        devds = util.dataset_mean(devds)
+    if dev is not None:
+        dev_data = reader(dev, drop_variables=skip_these_vars)
+        if time_mean:
+            dev_data = util.dataset_mean(dev_data)
 
-    return refds, devds
+    return ref_data, dev_data
 
 
 def get_common_varnames(
-        refds,
-        devds,
-        var_prefix=None,
+        refdata,
+        devdata,
+        prefix,
         verbose=False,
+):
     """
+    Returns an alphabetically-sorted list of common variables two
+    xr.Dataset objects matching a given prefix.
+
+    Args:
+    -----
+    refdata (xr.Dataset ) : Data from the Ref model.
+    devdata (xr.Dataset ) : Data from the Dev model.
+    prefix  (str        ) : Variable prefix to match.
+    verbose (bool       ) : Toggle verbose printout on/off.
+
+    Returns:
+    --------
+    varlist (list of str) : Sorted list of common variable names.
     """
-    
-    # Get list of variables in collection
-    vardict = util.compare_varnames(refds, devds, quiet=not verbose)
-    varlist = [v for v in vardict["commonvars3D"] if collection + "_" in v]
+    vardict = util.compare_varnames(refdata, devdata, quiet=not verbose)
+    varlist = [var for var in vardict["commonvars"] if prefix in var]
 
-    # Select variables having a common prefix
-    if var_prefix is not None:
-        varlist = [v for v in varlist if var_prefix in v]
+    return sorted(varlist)
 
-    return varlist.sort()
+
+def print_sigdiffs(
+        sigdiff_files,
+        sigdiff_list,
+        sigdiff_type,
+        sigdiff_cat
+):
+    """
+    Write
+    Appends a list of species showing significant differences in a
+    benchmark plotting category to a file.
+
+    sigdiff_files (list|None) :
+    sigdiff_list  (list     ) : List of significant differences.
+    sigdiff_cat   (str      ) : e.g. "Oxidants", "Aerosols", "DryDep", etc.
+    sigdiff_file  (str      ) : Filename to which the list will be appended
+    """
+    if sigdiff_files is not None:
+        for ofile in sigdiff_files:
+            if sigdiff_type in ofile:
+                write_sigdiff(sigdiff_list, sigdiff_cat, ofile)
+
+
+def write_sigdiff(
+        sigdiff_list,
+        sigdiff_cat,
+        sigdiff_file,
+):
+    """
+    Appends a list of species showing significant differences in a
+    benchmark plotting category to a file.
+
+    sigdiff_list (list ) : List of significant differences.
+    sigdiff_cat  (str  ) : e.g. "Oxidants", "Aerosols", "DryDep", etc.
+    sigdiff_file (str  ) : Filename to which the list will be appended
+    """
+    util.verify_variable_type(sigdiff_list, list)
+    util.verify_variable_type(sigdiff_title, str)
+    util.verify_variable_type(sigdiff_file, str)
+
+    with open(sigdiff_file, "a+", encoding="UTF-8") as ofile:
+        print(f"* {sigdiff_cat}: ", file=ofile, end="")
+        for var in sigdiff_list:
+            print(f"{var} ", file=ofile, end="")
+        print(file=ofile)
+        ofile.close()
+
+
+def pdf_filename(
+        dst,
+        collection,
+        subdst,
+        plot_type
+):
+    """
+    Creates the absolute path for a PDF file containing benchmark plots.
+
+    Args:
+    -----
+    dst        (str     ) : Root folder for benchmark output plots
+    collection (str     ) : e.g. "Aerosols", "DryDep", etc.
+    subdst     (str|None) : e.g. "AnnualMean", "Apr2019", etc.
+    plot_type  (str     ) : e.g. "Surface", "FullColumnZonalMean", etc.
+
+    Returns:
+    --------
+    pdf_path (str) : Absolute path for the PDF file containing plots
+    """
+    util.verify_variable_type(dst, str)
+    util.verify_variable_type(collection, str)
+    util.verify_variable_type(subdst, (str, type(None)))
+
+    pdf_path = f"{collection}_{plot_type}.pdf"
+    if subdst is not None:
+        pdf_path = f"{collection}_{plot_type}_{subdst}.pdf"
+
+    return os.path.join(dst, pdf_path)
+
+
+def print_benchmark_info(
+        config
+):
+    """
+    Prints which benchmark plots and tables will be generated.
+
+    Args:
+    -----
+    config (dict) : Inputs from the benchmark config YAML file.
+    """
+    util.verify_variable_type(config, dict)
+
+    conf = config["options"]["bmk_type"]
+    print(f"The following plots and tables will be created for {conf}")
+
+    conf = config["options"]["outputs"]
+    for key in conf.keys():
+        if "plot_conc" in key and conf[key]:
+            print(" - Concentration plots")
+        if "plot_emis" in key and conf[key]:
+            print(" - Emissions plots")
+        if "plot_jvalues" in key and conf[key]:
+            print(" - J-values (photolysis rates) plots")
+        if "plot_aod" in key and conf[key]:
+            print(" - Aerosol optical depth plots")
+        if "plot_drydep" in key and conf[key]:
+            print(" - Drydep velocity plots")
+        if "plot_wetdep" in key and conf[key]:
+            print(" - Convective and large-scale wet deposition plots")
+        if "plot_models_vs_obs" in key and conf[key]:
+            print(" - Plots of models vs. observations")
+        if "emis_table" in key and conf[key]:
+            print(" - Table of emissions totals by species and inventory")
+        if "rnpbbe_budget" in key and conf[key]:
+            print(" - Radionuclides budget table")
+        if "ops_budget_table" in key and conf[key]:
+            print(" - Operations budget tables")
+        if "aer_budget_table" in key and conf[key]:
+            print(" - Aerosol budget/burden tables")
+        if "mass_table" in key and conf[key]:
+            print(" - Table of species mass")
+        if "mass_accum_table" in key and conf[key]:
+            print(" - Table of species mass accumulation")
+        if "OH_metrics" in key and conf[key]:
+            print(" - Table of OH metrics")
+        if "ste_table" in key and conf[key]:
+            print(" - Table of strat-trop exchange")
+        if "cons_table" in key and conf[key]:
+            print(" - Table of mass conservation")
+
+    print("Comparisons will be made for the following combinations:")
+    conf = config["options"]["comparisons"]
+    if conf["gcc_vs_gcc"]["run"]:
+        print(" - GCC vs GCC")
+    if conf["gchp_vs_gcc"]["run"]:
+        print(" - GCHP vs GCC")
+    if conf["gchp_vs_gchp"]["run"]:
+        print(" - GCHP vs GCHP")
+    if conf["gchp_vs_gcc_diff_of_diffs"]["run"]:
+        print(" - GCHP vs GCC diff of diffs")

--- a/gcpy/benchmark/modules/benchmark_utils.py
+++ b/gcpy/benchmark/modules/benchmark_utils.py
@@ -33,7 +33,7 @@ def make_output_dir(
     """
     util.verify_variable_type(dst, str)
     util.verify_variable_type(collection, str)
-    util.verify_variable_type(subdst, (str, None))
+    util.verify_variable_type(subdst, (str, type(None)))
 
     # Create the destination folder (if it doesn't exist)
     util.make_directory(dst, overwrite)
@@ -131,11 +131,16 @@ def print_sigdiffs(
     Appends a list of species showing significant differences in a
     benchmark plotting category to a file.
 
-    sigdiff_files (list|None) :
-    sigdiff_list  (list     ) : List of significant differences.
+    sigdiff_files (list|None) : List of files for signficant diffs output
+    sigdiff_list  (list     ) : List of significant differences to print
+    sigdiff_type  (str      ) : e.g. "sfc", "500hPa", "zm"
     sigdiff_cat   (str      ) : e.g. "Oxidants", "Aerosols", "DryDep", etc.
-    sigdiff_file  (str      ) : Filename to which the list will be appended
     """
+    util.verify_variable_type(sigdiff_files, (list, type(None)))
+    util.verify_variable_type(sigdiff_list, list)
+    util.verify_variable_type(sigdiff_type, str)
+    util.verify_variable_type(sigdiff_cat, str)
+
     if sigdiff_files is not None:
         for ofile in sigdiff_files:
             if sigdiff_type in ofile:
@@ -156,7 +161,7 @@ def write_sigdiff(
     sigdiff_file (str  ) : Filename to which the list will be appended
     """
     util.verify_variable_type(sigdiff_list, list)
-    util.verify_variable_type(sigdiff_title, str)
+    util.verify_variable_type(sigdiff_cat, str)
     util.verify_variable_type(sigdiff_file, str)
 
     with open(sigdiff_file, "a+", encoding="UTF-8") as ofile:

--- a/gcpy/benchmark/modules/benchmark_utils.py
+++ b/gcpy/benchmark/modules/benchmark_utils.py
@@ -1,0 +1,106 @@
+"""
+Specific utilities for creating plots from GEOS-Chem benchmark simulations.
+
+TODO: Migrate benchmark-specific utilities from gcpy/benchmark.py to here.
+"""
+import os
+import gc
+import numpy as np
+from gcpy import util
+from gcpy.constants import skip_these_vars
+from gcpy.plot.compare_single_level import compare_single_level
+from gcpy.plot.compare_zonal_mean import compare_zonal_mean
+
+# Suppress numpy divide by zero warnings to prevent output spam
+np.seterr(divide="ignore", invalid="ignore")
+
+
+def make_collection_subdir(
+        dst,
+        collection,
+        datestr
+):
+    """
+    Creates a subdirectory for the given collection type
+    in the destination directory.
+
+    Args:
+    ----
+    dst        (str) : Destination directory
+    collection (str) : Collection name
+    datestr    (str) : Date string
+
+    Returns:
+    --------
+    target_dst (str) : Directory that was created
+
+    """
+
+    # Make a collection subdirectory
+    target_dst = os.path.join(dst, collection)
+    if not os.path.isdir(target_dst):
+        os.mkdir(target_dst)
+
+    # If datestr is passed, create a further subdirectory
+    if datestr is not None:
+        target_dst = os.path.join(target_dst, datestr)
+        if not os.path.isdir(target_dst):
+            os.mkdir(target_dst)
+
+    return target_dst
+
+
+def read_ref_and_dev(
+        ref,
+        dev,
+        time_mean=False,
+        verbose=False
+):
+    """
+    Reads files from the Ref and Dev models into xarray.Dataset objects.
+
+
+    Args:
+    -----
+    ref (str or list) : Ref data file(s)
+    def (str or list) : Ref data file(s)
+    time_mean (bool)  : Return the average over the time dimension
+
+    Returns:
+    --------
+    refds (xarray.Dataset) : Data from the Ref model
+    devds (xarray.Dataset) : Data from the Dev model
+    """
+
+    # Get the function that will read file(s) into a dataset
+    reader = util.dataset_reader(time_mean, verbose=verbose)
+
+    # Open datasets
+    refds = reader(ref, drop_variables=skip_these_vars)
+    devds = reader(dev, drop_variables=skip_these_vars)
+
+    # Take
+    if time_mean:
+        refds = util.dataset_mean(refds)
+        devds = util.dataset_mean(devds)
+
+    return refds, devds
+
+
+def get_common_varnames(
+        refds,
+        devds,
+        var_prefix=None,
+        verbose=False,
+    """
+    """
+    
+    # Get list of variables in collection
+    vardict = util.compare_varnames(refds, devds, quiet=not verbose)
+    varlist = [v for v in vardict["commonvars3D"] if collection + "_" in v]
+
+    # Select variables having a common prefix
+    if var_prefix is not None:
+        varlist = [v for v in varlist if var_prefix in v]
+
+    return varlist.sort()

--- a/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -67,7 +67,7 @@ import gcpy.benchmark.modules.benchmark_utils as bmk_util
 #TODO: Peel out routines from benchmark_funcs.py into smaller
 # routines in the gcpy/benchmark/modules folder, such as these:
 from gcpy.benchmark.modules.benchmark_drydep \
-    import make_benchmark_drydep_plots
+    import drydepvel_species, make_benchmark_drydep_plots
 
 # Tell matplotlib not to look for an X-window
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
@@ -310,6 +310,10 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
     bmk_mons_gchp_dev = all_months_gchp_dev[bmk_mon_inds]
     bmk_sec_per_month_dev = sec_per_month_dev[bmk_mon_inds]
 
+    # List of species for dry deposition velocity plots
+        
+    # Get common variables between Ref 
+    
     # ======================================================================
     # Print the list of plots & tables being generated
     # ======================================================================
@@ -658,7 +662,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                varlist=drydepvel_species()
             )
 
             # --------------------------------------------------------------
@@ -679,7 +684,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     weightsdir=config["paths"]["weights_dir"],
                     overwrite=True,
                     spcdb_dir=spcdb_dir,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    varlist=drydepvel_species()
                 )
 
         # ==================================================================
@@ -1262,7 +1268,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                varlist=drydepvel_species()                
             )
 
             # --------------------------------------------------------------
@@ -1283,7 +1290,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     weightsdir=config["paths"]["weights_dir"],
                     overwrite=True,
                     spcdb_dir=spcdb_dir,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    varlist=drydepvel_species()
                 )
 
         # ==================================================================
@@ -1916,7 +1924,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
                 spcdb_dir=spcdb_dir,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                varlist=drydepvel_species()                
             )
 
             # --------------------------------------------------------------
@@ -1938,7 +1947,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     weightsdir=config["paths"]["weights_dir"],
                     overwrite=True,
                     spcdb_dir=spcdb_dir,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    varlist=drydepvel_species()
                 )
 
         # ==================================================================

--- a/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -1227,20 +1227,20 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 )
 
         # ==================================================================
-        # GCC vs. GCC drydep plots
+        # GCHP vs. GCC drydep plots
         # ==================================================================
         if config["options"]["outputs"]["plot_drydep"]:
             print("\n%%% Creating GCHP vs. GCC drydep plots %%%")
 
             # --------------------------------------------------------------
-            # GCC vs GCC drydep plots: Annual mean
+            # GCHP vs GCC drydep plots: Annual mean
             # --------------------------------------------------------------
 
             # Filepaths
             ref = get_filepaths(
-                gcc_vs_gcc_refdir,
+                gchp_vs_gcc_refdir,
                 "DryDep",
-                all_months_ref
+                all_months_dev
             )[0]
             dev = get_filepaths(
                 gchp_vs_gcc_devdir,
@@ -1266,7 +1266,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
             )
 
             # --------------------------------------------------------------
-            # GCC vs GCC drydep plots: Seasonal
+            # GCHP vs GCC drydep plots: Seasonal
             # --------------------------------------------------------------
             for mon in range(bmk_n_months):
                 print(f"\nCreating plots for {bmk_mon_strs[mon]}")

--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -60,6 +60,7 @@ from gcpy.util import get_filepath, get_filepaths
 from gcpy import benchmark_funcs as bmk
 import gcpy.budget_tt as ttbdg
 import gcpy.ste_flux as ste
+import gcpy.benchmark.modules.benchmark_utils as bmk_util
 
 # Tell matplotlib not to look for an X-window
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
@@ -298,30 +299,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
         sec_per_yr_dev += days_in_mon * 86400.0
 
     # =======================================================================
-    # Print the list of plots & tables to the screen
+    # Print the list of plots & tables being generated
     # =======================================================================
-    print("The following plots and tables will be created for {}:".format(bmk_type))
-    if config["options"]["outputs"]["plot_conc"]:
-        print(" - Concentration plots")
-    if config["options"]["outputs"]["plot_wetdep"]:
-        print(" - Convective and large-scale wet deposition plots")
-    if config["options"]["outputs"]["rnpbbe_budget"]:
-        print(" - Radionuclides budget table")
-    if config["options"]["outputs"]["operations_budget"]:
-        print(" - Operations budget table")
-    if config["options"]["outputs"]["ste_table"]:
-        print(" - Table of strat-trop exchange")
-    if config["options"]["outputs"]["mass_table"]:
-        print(" - Table of species mass")
-    if config["options"]["outputs"]["cons_table"]:
-        print(" - Table of mass conservation")
-    print("Comparisons will be made for the following combinations:")
-    if config["options"]["comparisons"]["gcc_vs_gcc"]["run"]:
-        print(" - GCC vs GCC")
-    if config["options"]["comparisons"]["gchp_vs_gcc"]["run"]:
-        print(" - GCHP vs GCC")
-    if config["options"]["comparisons"]["gchp_vs_gchp"]["run"]:
-        print(" - GCHP vs GCHP")
+    bmk_util.print_benchmark_info(config)
 
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create GCC vs GCC benchmark plots and tables

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -54,7 +54,8 @@ from gcpy.benchmark.modules.run_1yr_fullchem_benchmark \
     import run_benchmark as run_1yr_benchmark
 from gcpy.benchmark.modules.run_1yr_tt_benchmark \
     import run_benchmark as run_1yr_tt_benchmark
-from gcpy.benchmark.modules.benchmark_6panel_plots \
+import gcpy.benchmark.modules.benchmark_utils as bmk_util
+from gcpy.benchmark.modules.benchmark_drydep \
     import make_benchmark_drydep_plots
 
 # Tell matplotlib not to look for an X-window
@@ -330,41 +331,7 @@ def run_benchmark_default(config):
     # ======================================================================
     # Print the list of plots & tables to the screen
     # ======================================================================
-    tmpstr = config["options"]["bmk_type"]
-    print(
-        f"The following plots and tables will be created for {tmpstr}"
-    )
-    if config["options"]["outputs"]["plot_conc"]:
-        print(" - Concentration plots")
-    if config["options"]["outputs"]["plot_emis"]:
-        print(" - Emissions plots")
-    if config["options"]["outputs"]["plot_jvalues"]:
-        print(" - J-values (photolysis rates) plots")
-    if config["options"]["outputs"]["plot_aod"]:
-        print(" - Aerosol optical depth plots")
-    if config["options"]["outputs"]["plot_drydep"]:
-        print(" - Drydep velocity plots")
-    if config["options"]["outputs"]["ops_budget_table"]:
-        print(" - Operations budget tables")
-    if config["options"]["outputs"]["emis_table"]:
-        print(" - Table of emissions totals by spc and inventory")
-    if config["options"]["outputs"]["mass_table"]:
-        print(" - Table of species mass")
-    if config["options"]["outputs"]["mass_accum_table"]:
-        print(" - Table of species mass accumulation")
-    if config["options"]["outputs"]["OH_metrics"]:
-        print(" - Table of OH metrics")
-    if config["options"]["outputs"]["ste_table"]:
-        print(" - Table of strat-trop exchange")
-    print("Comparisons will be made for the following combinations:")
-    if config["options"]["comparisons"]["gcc_vs_gcc"]["run"]:
-        print(" - GCC vs GCC")
-    if config["options"]["comparisons"]["gchp_vs_gcc"]["run"]:
-        print(" - GCHP vs GCC")
-    if config["options"]["comparisons"]["gchp_vs_gchp"]["run"]:
-        print(" - GCHP vs GCHP")
-    if config["options"]["comparisons"]["gchp_vs_gcc_diff_of_diffs"]["run"]:
-        print(" - GCHP vs GCC diff of diffs")
+    bmk_util.print_benchmark_info(config)
 
     # %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     # Create GCC vs GCC benchmark plots and tables
@@ -549,7 +516,7 @@ def run_benchmark_default(config):
             dev = get_filepath(gcc_vs_gcc_devdir, "DryDep", gcc_dev_date)
 
             # Create plots
-            make_benchmark_6panel_plots(
+            make_benchmark_drydep_plots(
                 ref,
                 gcc_vs_gcc_refstr,
                 dev,
@@ -560,7 +527,6 @@ def run_benchmark_default(config):
                 sigdiff_files=gcc_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"],
-                var_prefix="DryDepVel"
             )
 
 
@@ -692,17 +658,6 @@ def run_benchmark_default(config):
         # ==================================================================
         if config["options"]["outputs"]["summary_table"]:
             print("\n%%% Creating GCC vs. GCC summary table %%%")
-
-            # Diagnostic collections to check
-            collections = [
-                'AerosolMass',
-                'Aerosols',
-                'Emissions',
-                'JValues',
-                'Metrics',
-                'SpeciesConc',
-                'StateMet',
-            ]
 
             # Print summary of which collections are identical
             # between Ref & Dev, and which are not identical.

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -506,10 +506,10 @@ def run_benchmark_default(config):
             )
 
         # ==================================================================
-        # GCC vs GCC column drydep plots
+        # GCC vs GCC drydep plots
         # ==================================================================
         if config["options"]["outputs"]["plot_drydep"]:
-            print("\n%%% Creating GCC vs. GCC column drydep plots %%%")
+            print("\n%%% Creating GCC vs. GCC drydep plots %%%")
 
             # Filepaths
             ref = get_filepath(gcc_vs_gcc_refdir, "DryDep", gcc_ref_date)
@@ -528,7 +528,6 @@ def run_benchmark_default(config):
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"],
             )
-
 
         # ==================================================================
         # GCC vs GCC global mass tables
@@ -890,6 +889,35 @@ def run_benchmark_default(config):
                 sigdiff_files=gchp_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"]                
+            )
+
+        # ==================================================================
+        # GCHP vs GCC drydep plots
+        # ==================================================================
+        if config["options"]["outputs"]["plot_drydep"]:
+            print("\n%%% Creating GCHP vs. GCC drydep plots %%%")
+
+            # Filepaths
+            ref = get_filepath(gcc_vs_gcc_refdir, "DryDep", gcc_ref_date)
+            dev = get_filepath(
+                gchp_vs_gcc_devdir,
+                "DryDep",
+                gchp_dev_date,
+                is_gchp=True
+            )
+
+            # Create plots
+            make_benchmark_drydep_plots(
+                ref,
+                gchp_vs_gcc_refstr,
+                dev,
+                gchp_vs_gcc_devstr,
+                dst=gchp_vs_gcc_resultsdir,
+                weightsdir=config["paths"]["weights_dir"],
+                overwrite=True,
+                sigdiff_files=gchp_vs_gcc_sigdiff,
+                spcdb_dir=spcdb_dir,
+                n_job=config["options"]["n_cores"],
             )
 
         # ==================================================================
@@ -1320,6 +1348,40 @@ def run_benchmark_default(config):
             )
 
         # ==================================================================
+        # GCHP vs GCHP drydep plots
+        # ==================================================================
+        if config["options"]["outputs"]["plot_drydep"]:
+            print("\n%%% Creating GCHP vs. GCHP drydep plots %%%")
+
+            # Filepaths
+            ref = get_filepath(
+                gchp_vs_gchp_refdir,
+                "DryDep",
+                gchp_ref_date,
+                is_gchp=True
+            )
+            dev = get_filepath(
+                gchp_vs_gchp_devdir,
+                "DryDep",
+                gchp_dev_date,
+                is_gchp=True
+            )
+
+            # Create plots
+            make_benchmark_drydep_plots(
+                ref,
+                gchp_vs_gchp_refstr,
+                dev,
+                gchp_vs_gchp_devstr,
+                dst=gchp_vs_gchp_resultsdir,
+                weightsdir=config["paths"]["weights_dir"],
+                overwrite=True,
+                sigdiff_files=gchp_vs_gchp_sigdiff,
+                spcdb_dir=spcdb_dir,
+                n_job=config["options"]["n_cores"],
+            )
+
+        # ==================================================================
         # GCHP vs GCHP global mass tables
         # ==================================================================
         if config["options"]["outputs"]["mass_table"]:
@@ -1491,7 +1553,7 @@ def run_benchmark_default(config):
 
         # ==================================================================
         # GCHP vs GCHP Strat-Trop Exchange
-        # --------------------------------------------------------------
+        # ==================================================================
         if config["options"]["outputs"]["ste_table"]:
             print("\n%%% Skipping GCHP vs. GCHP Strat-Trop Exchange table %%%")
 

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -54,6 +54,8 @@ from gcpy.benchmark.modules.run_1yr_fullchem_benchmark \
     import run_benchmark as run_1yr_benchmark
 from gcpy.benchmark.modules.run_1yr_tt_benchmark \
     import run_benchmark as run_1yr_tt_benchmark
+from gcpy.benchmark.modules.benchmark_6panel_plots \
+    import make_benchmark_drydep_plots
 
 # Tell matplotlib not to look for an X-window
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
@@ -340,6 +342,8 @@ def run_benchmark_default(config):
         print(" - J-values (photolysis rates) plots")
     if config["options"]["outputs"]["plot_aod"]:
         print(" - Aerosol optical depth plots")
+    if config["options"]["outputs"]["plot_drydep"]:
+        print(" - Drydep velocity plots")
     if config["options"]["outputs"]["ops_budget_table"]:
         print(" - Operations budget tables")
     if config["options"]["outputs"]["emis_table"]:
@@ -533,6 +537,32 @@ def run_benchmark_default(config):
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"]
             )
+
+        # ==================================================================
+        # GCC vs GCC column drydep plots
+        # ==================================================================
+        if config["options"]["outputs"]["plot_drydep"]:
+            print("\n%%% Creating GCC vs. GCC column drydep plots %%%")
+
+            # Filepaths
+            ref = get_filepath(gcc_vs_gcc_refdir, "DryDep", gcc_ref_date)
+            dev = get_filepath(gcc_vs_gcc_devdir, "DryDep", gcc_dev_date)
+
+            # Create plots
+            make_benchmark_6panel_plots(
+                ref,
+                gcc_vs_gcc_refstr,
+                dev,
+                gcc_vs_gcc_devstr,
+                dst=gcc_vs_gcc_resultsdir,
+                weightsdir=config["paths"]["weights_dir"],
+                overwrite=True,
+                sigdiff_files=gcc_vs_gcc_sigdiff,
+                spcdb_dir=spcdb_dir,
+                n_job=config["options"]["n_cores"],
+                var_prefix="DryDepVel"
+            )
+
 
         # ==================================================================
         # GCC vs GCC global mass tables

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -898,7 +898,7 @@ def run_benchmark_default(config):
             print("\n%%% Creating GCHP vs. GCC drydep plots %%%")
 
             # Filepaths
-            ref = get_filepath(gcc_vs_gcc_refdir, "DryDep", gcc_ref_date)
+            ref = get_filepath(gchp_vs_gcc_refdir, "DryDep", gcc_ref_date)
             dev = get_filepath(
                 gchp_vs_gcc_devdir,
                 "DryDep",

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -56,7 +56,7 @@ from gcpy.benchmark.modules.run_1yr_tt_benchmark \
     import run_benchmark as run_1yr_tt_benchmark
 import gcpy.benchmark.modules.benchmark_utils as bmk_util
 from gcpy.benchmark.modules.benchmark_drydep \
-    import make_benchmark_drydep_plots
+    import drydepvel_species, make_benchmark_drydep_plots
 
 # Tell matplotlib not to look for an X-window
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
@@ -527,6 +527,7 @@ def run_benchmark_default(config):
                 sigdiff_files=gcc_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"],
+                varlist=drydepvel_species()
             )
 
         # ==================================================================
@@ -918,6 +919,7 @@ def run_benchmark_default(config):
                 sigdiff_files=gchp_vs_gcc_sigdiff,
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"],
+                varlist=drydepvel_species(),
             )
 
         # ==================================================================
@@ -1379,6 +1381,7 @@ def run_benchmark_default(config):
                 sigdiff_files=gchp_vs_gchp_sigdiff,
                 spcdb_dir=spcdb_dir,
                 n_job=config["options"]["n_cores"],
+                varlist=drydepvel_species()
             )
 
         # ==================================================================


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gcpy.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

This is the companion PR to #273.  We have added the option to plot drydep velocities as part of the standard benchmark outputs.

Updates in this version:
- Added script `gcpy/benchmark/modules/benchmark_utils.py` with a few utility functions.  
  - This is where we can continue to abstract utility function specific to benchmark plotting codes from `gcpy/util.py` and `gcpy/benchmark_funcs.py`.  
  - Eventually, all of the benchmarking code will be moved from `gcpy/gcpy` to `gcpy/benchmark/*`, so as to isolate them from other user functionality.

- Added script `gcpy/benchmark/modules/benchmark.drydep.py`, which contains function `make_benchmark_drydep_plots`.

- Modified the following scripts to call `make_benchmark_drydep_plots` from `benchmark_drydep.py`:
  - `gcpy/benchmark/run_benchmark.py`
  - `gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py`

- Added the `plot_drydep:True` YAML tag to:
  - `gcpy/benchmark/config/1yr_fullchem_benchmark.yml` 

- Added the `plot_drydep: False` YAML tag to:
  - `gcpy/benchmark/cloud/template.1hr_benchmark.yml`
  - `gcpy/benchmark/cloud/template.1mo_benchmark.yml`
  - `gcpy/benchmark/config/1yr_ftt_benchmark.yml`
  - `gcpy/benchmark/config/1mo_fullchem_benchmark.yml`

- Changed `operations_budget: False` to `ops_budget_table: False` in `gcpy/benchmark/config/1yr_tt_benchmark.yml`.  
  - This is to match the nomenclature used in the fullchem YAML files.

### Expected changes
- By default, drydep velocity plots are ENABED from in 1-yr fullchem benchmark output.
- By default, drydep velocity plots are DISABLED in 1-month and 1-hour fullchem benchmark output. 
  - Enabling this would require an update in the GEOS-Chem repository to archive the DryDep collection when running 1-month benchmark simulations.

### Related Github Issue(s)

- Closes #273, based on a suggestion by @mje1398