### PR TITLE
Fix dictionary key error when benchmark plots are generated sequentially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Example script `create_test_plot.py`, which can be used to check that GCPy has been installed properly
 - GitHub action `build-gcpy-environment` which tests installation of the mamba environment specified in in `docs/source/environment.yml`
 
+### Fixed
+- Prevent overwriting of the `results` variable when parallel plotting is deactivated (`n_cores: 1`)
+
 ## [1.4.1] - 2023-12-08
 ### Fixed
 - Now use the proper default value for the `--weightsdir` argument to `gcpy/file_regrid.py`

--- a/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -694,8 +694,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gcc_vs_gcc_mass_table(mon)
+                    results.append(gcc_vs_gcc_mass_table(mon))
 
         # ==================================================================
         # GCC vs GCC operations budgets tables
@@ -741,8 +742,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gcc_vs_gcc_ops_budg(mon)
+                    results.append(gcc_vs_gcc_ops_budg(mon))
 
         # ==================================================================
         # GCC vs GCC aerosols budgets/burdens tables
@@ -1255,8 +1257,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gchp_vs_gcc_mass_table(mon)
+                    results.append(gchp_vs_gcc_mass_table(mon))
 
         # ==================================================================
         # GCHP vs GCC operations budgets tables
@@ -1311,8 +1314,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gchp_vs_gcc_ops_budg(mon)
+                    results.append(gchp_vs_gcc_ops_budg(mon))
 
         # ==================================================================
         # GCHP vs GCC aerosol budgets and burdens tables
@@ -1863,8 +1867,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gchp_vs_gchp_mass_table(mon)
+                    results.append(gchp_vs_gchp_mass_table(mon))
 
         # ==================================================================
         # GCHP vs GCHP operations budgets tables
@@ -1921,8 +1926,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gchp_vs_gchp_ops_budg(mon)
+                    results.append(gchp_vs_gchp_ops_budg(mon))
 
         # ==================================================================
         # GCHP vs GCHP aerosol budgets and burdens tables

--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -540,8 +540,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gcc_vs_gcc_mass_table(mon)
+                    results.append(gcc_vs_gcc_mass_table(mon))
 
         # ==================================================================
         # GCC vs GCC operations budgets tables
@@ -837,8 +838,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gchp_vs_gcc_mass_table(mon)
+                    results.append(gchp_vs_gcc_mass_table(mon))
 
         # ==================================================================
         # GCHP vs GCC operations budgets tables
@@ -1149,8 +1151,9 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     for mon in range(bmk_n_months)
                 )
             else:
+                results = []
                 for mon in range(bmk_n_months):
-                    results = gchp_vs_gchp_mass_table(mon)
+                    results.append(gchp_vs_gchp_mass_table(mon))
 
         # ==================================================================
         # GCHP vs GCHP operations budgets tables

--- a/gcpy/benchmark_funcs.py
+++ b/gcpy/benchmark_funcs.py
@@ -1507,8 +1507,6 @@ def make_benchmark_conc_plots(
         for _, filecat in enumerate(catdict):
             results.append(createplots(filecat))
     # --------------------------------------------
-    print(results)
-    quit()
     
     dict_sfc = {list(result.keys())[0]: result[list(
         result.keys())[0]]['sfc'] for result in results}

--- a/gcpy/benchmark_funcs.py
+++ b/gcpy/benchmark_funcs.py
@@ -1503,10 +1503,13 @@ def make_benchmark_conc_plots(
             for _, filecat in enumerate(catdict)
         )
     else:
+        results = []
         for _, filecat in enumerate(catdict):
-            results = createplots(filecat)
+            results.append(createplots(filecat))
     # --------------------------------------------
-
+    print(results)
+    quit()
+    
     dict_sfc = {list(result.keys())[0]: result[list(
         result.keys())[0]]['sfc'] for result in results}
     dict_500 = {list(result.keys())[0]: result[list(
@@ -1514,6 +1517,9 @@ def make_benchmark_conc_plots(
     dict_zm = {list(result.keys())[0]: result[list(
         result.keys())[0]]['zm'] for result in results}
 
+    print("stop here")
+    quit()
+    
     # ==============================================================
     # Write the list of species having significant differences,
     # which we need to fill out the benchmark approval forms.
@@ -1868,8 +1874,9 @@ def make_benchmark_emis_plots(
                 for c in emis_cats
             )
         else:
+            results = []
             for c in emis_cats:
-                results = createfile_hco_cat(c)
+                results.append(createfile_hco_cat(c))
         # ---------------------------------------
 
         dict_emis = {list(result.keys())[0]: result[list(result.keys())[0]]
@@ -1981,8 +1988,9 @@ def make_benchmark_emis_plots(
                 for _, filecat in enumerate(catdict)
             )
         else:
+            results = []
             for _, filecat in enumerate(catdict):
-                results = createfile_bench_cat(filecat)
+                results.append(createfile_bench_cat(filecat))
         #------------------------------------------------
 
         allcatspc = [spc for result in results for spc in result]

--- a/gcpy/plot/compare_single_level.py
+++ b/gcpy/plot/compare_single_level.py
@@ -1152,8 +1152,9 @@ def compare_single_level(
                     for i in range(n_var)
                 )
             else:
+                results = []
                 for i in range(n_var):
-                    results = createfig(i, temp_dir)
+                    results.append(createfig(i, temp_dir))
             # ---------------------------------------
 
             # update sig diffs after parallel calls

--- a/gcpy/plot/compare_zonal_mean.py
+++ b/gcpy/plot/compare_zonal_mean.py
@@ -1046,8 +1046,9 @@ def compare_zonal_mean(
                     for i in range(n_var)
                 )
             else:
+                results = []
                 for i in range(n_var):
-                    results = createfig(i, temp_dir)
+                    results.append(createfig(i, temp_dir))
             # ---------------------------------------
 
             # update sig diffs after parallel calls


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gcpy.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR to #285.  This fixes the issue described in #285 by making sure that we append function output to the `results` variable instead of overwriting it.  For example, in code blocks such as this:
```python
    # --------------------------------------------
    # Create the plots in parallel
    # Turn off parallelization if n_job=1
    if n_job != 1:
        results = Parallel(n_jobs=n_job)(
            delayed(createplots)(filecat)
            for _, filecat in enumerate(catdict)
        )
    else:
        for _, filecat in enumerate(catdict):
            results = createplots(filecat)
    # --------------------------------------------
```
we have updated the `else` block so that the output from the function call when parallelization is turned off is appended to a list rather than ovewritten:
```python
    else:
        results = []
        for _, filecat in enumerate(catdict):
            results.append(createplots(filecat))
```

### Expected changes
This will prevent benchmark plots from failing when `n_cores: 1` is specified in the YAML config file.

### Related Github Issue(s)
- Closes #285
