### PR TITLE
Add a GitHub action to auto-push GCPy releases directly to PyPi

### DIFF
--- a/.github/workflows/build-gcpy-environment.yml
+++ b/.github/workflows/build-gcpy-environment.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout the GCPy repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create "gcpy_env" environment
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -36,8 +36,3 @@ jobs:
       - name: Test if we can create a plot
         run: python -m gcpy.examples.plotting.create_test_plot
         shell: micromamba-shell {0}
-
-# Use Node.js version 20 to avoid deprecation warnings
-runs:
-  using: 'node20'
-  main: 'main.js'

--- a/.github/workflows/build-gcpy-environment.yml
+++ b/.github/workflows/build-gcpy-environment.yml
@@ -36,3 +36,8 @@ jobs:
       - name: Test if we can create a plot
         run: python -m gcpy.examples.plotting.create_test_plot
         shell: micromamba-shell {0}
+
+# Use Node.js version 20 to avoid deprecation warnings
+runs:
+  using: 'node20'
+  main: 'main.js'

--- a/.github/workflows/build-test-environment.yml
+++ b/.github/workflows/build-test-environment.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.9"]
     steps:
       - name: Checkout the GCPy repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create "testing" environment
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -36,3 +36,8 @@ jobs:
       - name: Test if we can create a plot
         run: python -m gcpy.examples.plotting.create_test_plot
         shell: micromamba-shell {0}
+
+# Use Node.js version 20 to avoid deprecation warnings        
+runs:
+  using: 'node20'
+  main: 'main.js'

--- a/.github/workflows/build-test-environment.yml
+++ b/.github/workflows/build-test-environment.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.9"]
     steps:
       - name: Checkout the GCPy repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create "testing" environment
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -36,8 +36,3 @@ jobs:
       - name: Test if we can create a plot
         run: python -m gcpy.examples.plotting.create_test_plot
         shell: micromamba-shell {0}
-
-# Use Node.js version 20 to avoid deprecation warnings        
-runs:
-  using: 'node20'
-  main: 'main.js'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,3 +80,8 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
+
+# Use Node.js version 20 to avoid deprecation warnings
+runs:
+  using: 'node20'
+  main: 'main.js'

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -37,8 +37,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_KEY }}
-
-# Use Node.js version 20 to avoid deprecation warnings
-runs:
-  using: 'node20'
-  main: 'main.js'

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,44 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload GCPy to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_KEY }}
+
+# Use Node.js version 20 to avoid deprecation warnings
+runs:
+  using: 'node20'
+  main: 'main.js'

--- a/.release/changeVersionNumbers.sh
+++ b/.release/changeVersionNumbers.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+#EOC
+#------------------------------------------------------------------------------
+#                  GEOS-Chem Global Chemical Transport Model                  !
+#------------------------------------------------------------------------------
+#BOP
+#
+# !MODULE: changeVersionNumbers.sh
+#
+# !DESCRIPTION: Bash script to change the version numbers in the appropriate
+#  files in the GCPy directory structure.  Run this before releasing a new
+#  GCPy version.
+#\\
+#\\
+# !CALLING SEQUENCE:
+#  $ ./changeVersionNumbers.sh X.Y.Z        # X.Y.Z = GCClassic version number
+#EOP
+#------------------------------------------------------------------------------
+#BOC
+
+function replace() {
+
+    #========================================================================
+    # Function to replace text in a file via sed.
+    # 
+    # 1st argument: Search pattern
+    # 2nd argument: Replacement text
+    # 3rd argument: File in which to search and replace
+    #========================================================================
+
+    sed -i -e "s/${1}/${2}/" "${3}"
+}
+
+ 
+function exitWithError() {
+
+    #========================================================================
+    # Display and error message and exit
+    #========================================================================
+
+    echo "Could not update version numbers in ${1}... Exiting!"
+    exit 1
+}
+
+
+function main() {
+
+    #========================================================================
+    # Replaces the version number in the files listed.
+    #
+    # 1st argument: New version number to use
+    #========================================================================
+
+    # New version number
+    version="${1}"
+
+    # Save this directory path and change to root directory
+    thisDir=$(pwd -P)
+    cd ..
+
+    #========================================================================
+    # Update version numbers in various files
+    #========================================================================
+
+    # Pattern to match: X.Y.Z
+    pattern='[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'
+
+    # List of files to replace
+    files=(                                                    \
+        "docs/source/conf.py"                                  \
+	"gcpy/_version.py"                                     \
+	"gcpy/benchmark/run_benchmark.py"                      \
+	"gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py" \
+	"gcpy/benchmark/modules/run_1yr_tt_benchmark.py"       \
+    )
+
+    # Replace version numbers in files
+    for file in ${files[@]}; do
+        replace "${pattern}" "${version}" "${file}"
+        [[ $? -ne 0 ]] && exitWithError "${file}"
+        echo "GCPy version updated to ${version} in ${file}"
+    done
+
+    #========================================================================
+    # Update version number and date in CHANGELOG.md
+    #========================================================================
+
+    # Pattern to match: "[Unreleased] - TBD"
+    pattern='\[.*Unreleased.*\].*'
+    date=$(date -Idate)
+
+    # List of files to replace
+    file="CHANGELOG.md"
+
+    # Replace version numbers in files
+    replace "${pattern}" "\[${version}\] - ${date}" "${file}"
+    [[ $? -ne 0 ]] && exitWithError "${file}"
+    echo "GCClassic version updated to ${version} in ${file}"
+
+    #========================================================================
+    # Update version number in setup.py
+    #========================================================================
+
+    # Split version number into an array
+    IFS='.' read -r -a version_numbers <<< "${version}"
+
+    # File to replace
+    file="setup.py"
+
+    # Replace version numbers
+    replace "MAJOR =.." "MAJOR = ${version_numbers[0]}" "${file}"
+    [[ $? -ne 0 ]] && exitWithError "${file}"
+    replace "MINOR =.." "MINOR = ${version_numbers[1]}" "${file}"
+    [[ $? -ne 0 ]] && exitWithError "${file}"
+    replace "MICRO =.." "MICRO = ${version_numbers[2]}" "${file}"
+    [[ $? -ne 0 ]] && exitWithError "${file}"
+
+    echo "GCPy version updated to ${version} in ${file}"
+    
+    # Return to the starting directory
+    cd "${thisDir}"
+}
+
+# ---------------------------------------------------------------------------
+
+# Expect 1 argument, or exit with error
+if [[ $# -ne 1 ]]; then
+    echo "Usage: ./changeVersionNumbers.sh VERSION"
+    exit 1
+fi
+
+# Replace version numbers
+main "${1}"
+
+# Return status
+exit $?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to GCPy will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Badge for `build-gcpy-environment` GitHub Action in `README.md`
+- Badges in `docs/source/index.rst`
+
 ### Changed
 - Bump pip from 23.2.1 to 23.3 (dependabot suggested this)
 - Bump pypdf from 3.16.1 to 3.17.0 (dependabot suggested this)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Badge for `build-gcpy-environment` GitHub Action in `README.md`
 - Badges in `docs/source/index.rst`
+- GitHub action to push GCPy releases to PyPi
 
 ### Changed
 - Bump pip from 23.2.1 to 23.3 (dependabot suggested this)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Badge for `build-gcpy-environment` GitHub Action in `README.md`
 - Badges in `docs/source/index.rst`
 - GitHub action to push GCPy releases to PyPi
+- Script `./release/changeVersionNumbers.sh`, used to update version numbers in various files befor release
 
 ### Changed
 - Bump pip from 23.2.1 to 23.3 (dependabot suggested this)

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 <p>
   <a href="https://github.com/geoschem/gcpy/releases"><img src="https://img.shields.io/github/v/release/geoschem/gcpy?include_prereleases&label=Latest%20Pre-Release"></a>
   <a href="https://github.com/geoschem/gcpy/releases"><img src="https://img.shields.io/github/v/release/geoschem/gcpy?label=Latest%20Stable%20Release"></a>
-  <a href="https://github.com/geoschem/gcpy/releases/"><img src="https://img.shields.io/github/release-date/geoschem/gcpy"></a>
-  <br />
   <a href="https://doi.org/10.5281/zenodo.3689589"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3689589.svg" alt="DOI"></a>
+ <br />
   <a href="https://github.com/geoschem/gcpy/blob/main/LICENSE.txt"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
+  <a href="https://github.com/geoschem/gcpy/releases/"><img src="https://img.shields.io/github/release-date/geoschem/gcpy"></a>
   <a href="https://gcpy.readthedocs.io/en/latest/"><img src="https://img.shields.io/readthedocs/gcpy?label=ReadTheDocs"></a>
+  <a href="https://github.com/geoschem/gcpy/actions/workflows/build-gcpy-environment.yml"><img src="https://github.com/geoschem/gcpy/actions/workflows/build-gcpy-environment.yml/badge.svg"></a>
 </p>
-
 
 **GCPy** is a Python-based toolkit containing useful functions for working specifically with the GEOS-Chem model of atmospheric chemistry and composition.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,6 +2,19 @@
 GCPy: GEOS-Chem Python toolkit
 ##############################
 
+.. raw:: html
+
+   <p>
+   <a href="https://github.com/geoschem/gcpy/releases"><img src="https://img.shields.io/github/v/release/geoschem/gcpy?include_prereleases&label=Latest%20Pre-Release"></a>
+   <a href="https://github.com/geoschem/gcpy/releases"><img src="https://img.shields.io/github/v/release/geoschem/gcpy?label=Latest%20Stable%20Release"></a>
+   <a href="https://doi.org/10.5281/zenodo.3689589"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3689589.svg" alt="DOI"></a>
+   <br />
+   <a href="https://github.com/geoschem/gcpy/blob/main/LICENSE.txt"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
+   <a href="https://github.com/geoschem/gcpy/releases/"><img src="https://img.shields.io/github/release-date/geoschem/gcpy"></a>
+   <a href="https://gcpy.readthedocs.io/en/latest/"><img src="https://img.shields.io/readthedocs/gcpy?label=ReadTheDocs"></a>
+   <a href="https://github.com/geoschem/gcpy/actions/workflows/build-gcpy-environment.yml"><img src="https://github.com/geoschem/gcpy/actions/workflows/build-gcpy-environment.yml/badge.svg"></a>
+   </p>
+
 Welcome to the GCPy ReadTheDocs documentation! This site provides documentation
 on the functionality of GCPy and instructions for common use cases.
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gcpy.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This PR adds the [Publish Python Package](https://github.com/geoschem/gcpy/new/main?filename=.github%2Fworkflows%2Fpython-publish.yml&workflow_template=ci%2Fpython-publish) GitHub action to the GCPy repository. 

Steps were:

1. I created an [PyPi API token](https://pypi.org/help/#apitoken) using my PyPi account.

2. I saved this token as a GCPy repository secret. 
    - I clicked on: `Settings -> Secrets and Variables -> Actions -> New repository secret`
    - I then copied & pasted the token into the text box under the name `PYPI_KEY`.

3. I copied the [python-publish.yml](https://github.com/geoschem/gcpy/new/main?filename=.github%2Fworkflows%2Fpython-publish.yml&workflow_template=ci%2Fpython-publish) file to `.github/workflows` and modified it accordingly.
    - I changed  `password: ${{ secrets.PYPI_API_TOKEN }}` to `password: ${{ secrets.PYPI_KEY }}`.  This will read the API token that I saved as a repository secret.
    - I also added text to the YAML file that will cause it to run with `Node.js` version 20 (which is the latest version).
  
4. Unrelated to the GitHub action, I also added the `.release/changeVersionNumbers.sh` script (adapted from https://github.com/geoschem/GCClassic).

### Expected changes

This is a zero-diff update w/r/t GCPy plotting and numerical functionality.  But each time we create a public GCPy release, it should create a corresponding release on PyPi.  From there a release on conda-forge can be created.

### Related Github Issue(s)

- Closes #29
- Closes #290 