### PR TITLE
file_regrid.py now uses `DELP_DRY` for delta-dry pressure variable name when creating GCHP files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,8 +80,3 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:${{matrix.language}}"
-
-# Use Node.js version 20 to avoid deprecation warnings
-runs:
-  using: 'node20'
-  main: 'main.js'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - CS inquiry functions in `gcpy/cstools.py` now work properly for `xr.Dataset` and `xr.DataArray` objects
 - Prevent an import error by using `seaborn-v0_8-darkgrid` in`gcpy/benchmark/modules/benchmark_models_vs_obs.py`
+- `gcpy/file_regrid.py` now creates GCHP files with `DELP_DRY` instead of `DELPDRY`
 
 ## [1.4.2] - 2024-01-26
 ### Added

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -1100,10 +1100,11 @@ def rename_restart_variables(
         # ==============================================================
         if towards_gchp:
             for var in dset.data_vars.keys():
-                if "Met_DELPDRY" in var:
-                    old_to_new[var] = "DELP_DRY"
                 if var.startswith("Met_"):
-                    old_to_new[var] = var.replace("Met_", "")
+                    if "DELPDRY" in var:
+                        old_to_new[var] = "DELP_DRY"
+                    else:
+                        old_to_new[var] = var.replace("Met_", "")
                 if var.startswith("Chem_"):
                     old_to_new[var] = var.replace("Chem_", "")
                 if var.startswith("SpeciesRst_"):
@@ -1117,7 +1118,7 @@ def rename_restart_variables(
         # checkpoint -> classic/diagnostic
         # ==============================================================
         for var in dset.data_vars.keys():
-            if var == "DELP_DRY":
+            if var == "DELP_DRY" or var == "DELPDRY":
                 old_to_new[var] = "Met_DELPDRY"
             if var == "BXHEIGHT":
                 old_to_new[var] = "Met_BXHEIGHT"


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gcpy.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
This is the companion PR to #296.  We have fixed a logic error that caused `file_regrid.py` to use the wrong variable name `DELPDRY` insstead of `DELP_DRY` when regridding to GCHP output files.

### Expected changes
Doing the following commands:
``` console
$ python -m gcpy.file_regrid --filein GEOSChem.Restart.20190101_0000z.nc4 \
       --dim_format_in classic \
       --fileout GEOSChem.Restart.20190101_0000z.c24.nc4 \
       --cs_res_out 24 \
       --dim_format_out checkpoint
$ ncdump -cts GEOSChem.Restart.20190101_0000z.c24.nc4 | grep "DELP"
```
Now results in this output:
```console
        float DELP_DRY(time, lev, lat, lon) ;
                DELP_DRY:_FillValue = NaNf ;
                DELP_DRY:long_name = "Delta-pressure across grid box (dry air)" ;
                DELP_DRY:units = "hPa" ;
                DELP_DRY:averaging_method = "instantaneous" ;
                DELP_DRY:_Storage = "chunked" ;
                DELP_DRY:_ChunkSizes = 1, 72, 144, 24 ;
                DELP_DRY:_Endianness = "little" ;
```

### Related Github Issue(s)
- Closes #296 
