### PR TITLE
Fix bugs in 1-yr benchmarks for different GCHP grid resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CS inquiry functions in `gcpy/cstools.py` now work properly for `xr.Dataset` and `xr.DataArray` objects
 - Prevent an import error by using `seaborn-v0_8-darkgrid` in`gcpy/benchmark/modules/benchmark_models_vs_obs.py`
 - `gcpy/file_regrid.py` now creates GCHP files with `DELP_DRY` instead of `DELPDRY`
+- Fixed bugs in GCHP vs GCHP sections of 1-yr benchmark run scripts to allow comparison of GCHP runs with different grid resolutions
 
 ## [1.4.2] - 2024-01-26
 ### Added

--- a/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -1995,8 +1995,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Restart",
                     bmk_end_ref,
                     is_gchp=True,
-                    gchp_res=config["data"]["dev"]["gchp"]["resolution"],
-                    gchp_is_pre_14_0=config["data"]["dev"]["gchp"][
+                    gchp_res=config["data"]["ref"]["gchp"]["resolution"],
+                    gchp_is_pre_14_0=config["data"]["ref"]["gchp"][
                         "is_pre_14.0"]
                 )
                 devareapath = get_filepath(

--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -1094,8 +1094,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     "Restart",
                     bmk_end_ref,
                     is_gchp=True,
-                    gchp_res=config["data"]["dev"]["gchp"]["resolution"],
-                    gchp_is_pre_14_0=config["data"]["dev"]["gchp"][
+                    gchp_res=config["data"]["ref"]["gchp"]["resolution"],
+                    gchp_is_pre_14_0=config["data"]["ref"]["gchp"][
                         "is_pre_14.0"]
                 )
                 devareapath = get_filepath(


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

I ran into problems comparing GCHP runs at two different grid solutions using the 1-year transport tracer benchmark in GCPy. I traced the problem to usage of dev grid resolution ref area when generating mass tables. I checked the 1-year full chemistry benchmark and found the same issue. This update corrects the problem.

### Expected changes

1-year transport tracer benchmark can now be done comparing GCHP at different grid resolutions. The same issue is fixed for full chemistry simulation but I did not test.

### Reference(s)

None

### Related Github Issue(s)

None
