### PR TITLE
Fix bugs in GCC vs GCHP transport tracer benchmark mass tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - CS inquiry functions in `gcpy/cstools.py` now work properly for `xr.Dataset` and `xr.DataArray` objects
 - Prevent an import error by using `seaborn-v0_8-darkgrid` in`gcpy/benchmark/modules/benchmark_models_vs_obs.py`
+- Fixed silent bug in transport tracer benchmark GCC vs GCHP mass tables preventing them from being generated
 
 ## [1.4.2] - 2024-01-26
 ### Added

--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -128,8 +128,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
     )
     gchp_vs_gcc_refrstdir = os.path.join(
         config["paths"]["main_dir"],
-        config["data"]["ref"]["gchp"]["dir"],
-        config["data"]["ref"]["gchp"]["restarts_subdir"]
+        config["data"]["ref"]["gcc"]["dir"],
+        config["data"]["ref"]["gcc"]["restarts_subdir"]
     )
     gchp_vs_gchp_refrstdir = os.path.join(
         config["paths"]["main_dir"],

--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -810,6 +810,20 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         "is_pre_14.0"]
                 )
 
+                # Create tables
+                bmk.make_benchmark_mass_tables(
+                    refpath,
+                    gchp_vs_gcc_refstr,
+                    devpath,
+                    gchp_vs_gcc_devstr,
+                    dst=gchp_vs_gcc_tablesdir,
+                    subdst=bmk_mon_yr_strs_dev[mon],
+                    label=f"at 01{bmk_mon_yr_strs_dev[mon]}",
+                    overwrite=True,
+                    spcdb_dir=spcdb_dir,
+                    dev_met_extra=devareapath
+                )
+
             # Create tables in parallel
             # Turn off parallelization if n_jobs==1
             if config["options"]["n_cores"] != 1:


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes two bugs that were preventing generation of the GCC vs GCHP mass tables in the transport tracer benchmark. One of the problems was the reference restart path used the GCHP run directory rather than GCC. This bug went undetected because of the second problem, which omitted the call to generate the GCC vs GCHP mass tables altogether.

These problems also went under the radar because GCC vs GCHP global mass tables are not posted as part of the 1-year benchmark tables per version. The tables can now be generated and so should be included on the GEOS-Chem version pages.

### Expected changes

GCC vs GCHP global mass tables with now be generated in the 1-yr transport tracer benchmark.

### Reference(s)

None

### Related Github Issue(s)

None
