### PR TITLE
Bug fix for operations budget name in transport tracer benchmark run script

### DIFF
--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -527,7 +527,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
         # ==================================================================
         # GCC vs GCC operations budgets tables
         # ==================================================================
-        if config["options"]["outputs"]["operations_budget"]:
+        if config["options"]["outputs"]["ops_budget_table"]:
             print("\n%%% Creating GCC vs. GCC operations budget tables %%%")
 
             # Filepaths
@@ -839,7 +839,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
         # ==================================================================
         # GCHP vs GCC operations budgets tables
         # ==================================================================
-        if config["options"]["outputs"]["operations_budget"]:
+        if config["options"]["outputs"]["ops_budget_table"]:
             print("\n%%% Creating GCHP vs. GCC operations budget tables %%%")
 
             # Filepaths
@@ -1152,7 +1152,7 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
         # ==================================================================
         # GCHP vs GCHP operations budgets tables
         # ==================================================================
-        if config["options"]["outputs"]["operations_budget"]:
+        if config["options"]["outputs"]["ops_budget_table"]:
             print("\n%%% Creating GCHP vs. GCHP operations budget tables %%%")
 
             # Filepaths


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR fixes an error in the dev branch when running transport tracer 1-year benchmarks. The operations budget string was changed in the config file and needed to be changed in the transport tracer run script too. No updates needed for changelog since the bug came in within this version.

### Expected changes

None

### Reference(s)

None

### Related Github Issue(s)

None
