### PR TITLE
Added missing options to 1yr_ch4_benchmark.yml config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed silent bug in transport tracer benchmark GCC vs GCHP mass tables preventing them from being generated
 - Import error in `gcpy/examples/diagnostics/compare_diags.py`
 - Added missing `n_cores` to `gcpy/examples/diagnostics/compare_diags.yml`
+- Added missing `plot_drydep` option to `gcpy/gcpy/benchmark/config/1yr_ch4_benchmark.yml`
 
 ### Removed
 - Example script `gcpy/examples/plotting/mda8_o3_timeseries.py`

--- a/gcpy/benchmark/config/1yr_ch4_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_ch4_benchmark.yml
@@ -30,6 +30,17 @@ paths:
   results_dir: /path/to/BenchmarkResults   # EDIT AS NEEDED
   weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
+  #
+  # Observational data dirs are on Harvard Cannon, edit if necessary
+  #
+  obs_data:
+    ebas_o3:
+      data_dir: /n/jacob_lab/Lab/obs_data_for_bmk/ebas_sfc_o3_2019
+      data_label: "O3 (EBAS, 2019)"
+    sondes:
+      data_dir: /n/jacob_lab/Lab/obs_data_for_bmk/sondes_2010-2019
+      data_file: allozonesondes_2010-2019.csv
+      site_file: allozonesondes_site_elev.csv
 #
 # data: Contains configurations for ref and dev runs
 #   version:         Version string (must not contain spaces)
@@ -111,6 +122,7 @@ options:
     emis_table: True
     plot_jvalues: False
     plot_aod: False
+    plot_drydep: False
     mass_table: True
     ops_budget_table: False
     aer_budget_table: False


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard / GCST

### Describe the update

The `plot_drydep` and Observational data options were missing from 1yr_ch4_benchmark.yml causing gcpy to crash. These are not used in CH4 benchmarks but have been added for consistency with other config files.

### Expected changes

This is a zero difference update.