### PR TITLE
Fix issues in cubed-sphere regridding

### DIFF
--- a/gcpy/benchmark_funcs.py
+++ b/gcpy/benchmark_funcs.py
@@ -1517,7 +1517,7 @@ def make_benchmark_conc_plots(
 
     print("stop here")
     quit()
-
+    
     # ==============================================================
     # Write the list of species having significant differences,
     # which we need to fill out the benchmark approval forms.

--- a/gcpy/benchmark_funcs.py
+++ b/gcpy/benchmark_funcs.py
@@ -1514,9 +1514,6 @@ def make_benchmark_conc_plots(
         result.keys())[0]]['500'] for result in results}
     dict_zm = {list(result.keys())[0]: result[list(
         result.keys())[0]]['zm'] for result in results}
-
-    print("stop here")
-    quit()
     
     # ==============================================================
     # Write the list of species having significant differences,

--- a/gcpy/benchmark_funcs.py
+++ b/gcpy/benchmark_funcs.py
@@ -1514,7 +1514,10 @@ def make_benchmark_conc_plots(
         result.keys())[0]]['500'] for result in results}
     dict_zm = {list(result.keys())[0]: result[list(
         result.keys())[0]]['zm'] for result in results}
-    
+
+    print("stop here")
+    quit()
+
     # ==============================================================
     # Write the list of species having significant differences,
     # which we need to fill out the benchmark approval forms.

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -758,6 +758,12 @@ def reformat_dims(
         })
         return ds_out
 
+    # Filter non-existent coordinates/dimensions
+    def rename_existing(ds, rename_dict):
+        existing_keys = set(ds.coords) | set(ds.dims)
+        filtered_rename_dict = {key: value for key, value in rename_dict.items() if key in existing_keys}
+        return ds.rename(filtered_rename_dict)
+
     dim_formats = {
         'checkpoint': {
             'unravel': [unravel_checkpoint_lat],
@@ -790,13 +796,13 @@ def reformat_dims(
             ds = unravel_callback(ds)
 
         # Rename dimensions
-        ds = ds.rename(dim_formats[format].get('rename', {}))
+        ds = rename_existing(ds, dim_formats[format].get('rename', {}))
         return ds
 
 
     # %%%% Renaming from the common format %%%%
     # Reverse rename
-    ds = ds.rename(
+    ds = rename_existing(ds, 
         {v: k for k, v in dim_formats[format].get('rename', {}).items()})
 
     # Ravel dimensions

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -426,7 +426,7 @@ def create_regridders(
                     "Warning: zonal mean comparison must be lat-lon. Defaulting to 1x1.25")
                 cmpres = '1x1.25'
                 cmpgridtype = "ll"
-            elif sg_ref_params != [] or sg_dev_params != []:
+            elif sg_ref_params != [1, 170, -90] or sg_dev_params != [1, 170, -90]:
                 # pick ref grid when a stretched-grid and non-stretched-grid
                 # are passed
                 cmpres = refres

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -785,7 +785,8 @@ def reformat_dims(
                 'Ydim': 'Y',
                 'time': 'T',
             },
-            'transpose': ('time', 'lev', 'nf', 'Xdim', 'Ydim')
+            # match format of GCHP output
+            'transpose': ('time', 'lev', 'nf', 'Ydim', 'Xdim')
         }
     }
 
@@ -810,16 +811,7 @@ def reformat_dims(
         ds = ravel_callback(ds)
 
     # Transpose
-    if len(ds.dims) == 5 or (len(ds.dims) == 4 and 'lev' in list(
-            ds.dims) and 'time' in list(ds.dims)):
-        # full dim dataset
-        ds = ds.transpose(*dim_formats[format].get('transpose', []))
-    elif len(ds.dims) == 4:
-        # single time
-        ds = ds.transpose(*dim_formats[format].get('transpose', [])[1:])
-    elif len(ds.dims) == 3:
-        # single level / time
-        ds = ds.transpose(*dim_formats[format].get('transpose', [])[2:])
+    ds = ds.transpose(*[x for x in dim_formats[format].get('transpose', []) if x in list(ds.dims)])
     return ds
 
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Confirm you have reviewed the following documentation

- [x] [Contributing guidelines](https://gcpy.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update

Fixed bugs about cube-sphere regridding formatting mentioned in #310 

### Expected changes

1) Now cube-sphere regridding in `file_regrid` would have correct shape of value array for single level plotting in `single_panel`.
2) Now `compare_single_level` will automatically choose the higher resolution between two standard cube-sphere grids, and also having correct unflipped `absdiff` and `fracdiff`. (see the figure below)
3) Now will not trigger renaming error when 2D data (Emissions, column AODs) that needs regridding is passed to `compare_single_level`.
4) delete code for quiting benchmark (which is already included in dev branch)

![image](https://github.com/geoschem/gcpy/assets/84134417/e22ffaef-3537-4bed-829e-d968ceed79f9)

### Reference(s)

None

### Related Github Issue(s)

#310 
