### PR TITLE
Add HCl to emissions_species.yml for GEOS-Chem 14.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Example script `gcpy/examples/hemco/make_mask_file.py`
 - Added `gcpy/community/format_hemco_data.py` from @hannahnesser
 - Added `gcpy/examples/hemco/format_hemco_demo.py` from @hannahnesser
-- Added HCl to `gcpy/benchmark/modules/emission_species.yml` for GEOS-Chem 14.4.0
+- Added HCl to `gcpy/benchmark/modules/emission_species.yml` and GTChlorine to `gcpy/benchmark/modules/emission_inventories.yml` for GEOS-Chem 14.4.0
 
 ### Changed
 - Bump pip from 23.2.1 to 23.3 (dependabot suggested this)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Example script `gcpy/examples/hemco/make_mask_file.py`
 - Added `gcpy/community/format_hemco_data.py` from @hannahnesser
 - Added `gcpy/examples/hemco/format_hemco_demo.py` from @hannahnesser
-  
+- Added HCl to `gcpy/benchmark/modules/emission_species.yml` for GEOS-Chem 14.4.0
+
 ### Changed
 - Bump pip from 23.2.1 to 23.3 (dependabot suggested this)
 - Bump pypdf from 3.16.1 to 3.17.0 (dependabot suggested this)

--- a/gcpy/benchmark/modules/emission_inventories.yml
+++ b/gcpy/benchmark/modules/emission_inventories.yml
@@ -9,6 +9,7 @@ FullChemBenchmark:
   DICEAfrica: Tg
   GEIAnatural: Tg
   GFED: Tg
+  GTChlorine: Tg
   IODINE: Tg
   LIANG: Tg
   LIGHTNOX: Tg

--- a/gcpy/benchmark/modules/emission_species.yml
+++ b/gcpy/benchmark/modules/emission_species.yml
@@ -26,6 +26,7 @@ FullChemBenchmark:
   GLYC: Tg
   GLYX: Tg
   HAC: Tg
+  HCl: Tg
   HCOOH: Tg
   HNO2: Tg
   HNO3: Tg


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

In GEOS-Chem 14.4.0 continental emissions of Chlorine (pCl and HCl) are added. We need to also include those emissions in benchmark plots and tables.

### Related Github Issue(s)

- https://github.com/geoschem/geos-chem/pull/2275
