### PR TITLE
Now use comma-separated list for `exempt-issue-labels` YAML tag in `stale.yml`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,14 +22,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'stale'
-        exempt-issue-labels:
-          - 'category: Discussion'
-          - 'category: Feature Request'
-          - 'deferred'
-          - 'help needed: Open Research Problem'
-          - 'help needed: Request Input from Community'
-          - 'never stale'
-          - 'TODO: Documentation'
+        exempt-issue-labels: 'category: Discussion','category: Feature Request','deferred','help needed: Open Research Problem','help needed: Request Input from Community','never stale','TODO: Documentation'
         days-before-issue-stale: 30
         days-before-issue-close: 7
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. If there are no updates within 7 days it will be closed. You can add the "never stale" tag to prevent the issue from closing this issue.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
+
 ## [1.5.0] - 2024-05-29
 ### Added
 - Script `gcpy/benchmark/modules/benchmark_utils.py`, with common benchmark utility functions


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have fixed a formatting issue in `.github/workflows/stale.yml` that was causing the "Mark stale issues" action not to run.

### Related Github Issue
- See description of issue in https://github.com/geoschem/geos-chem/issues/2307