### PR TITLE
Update package versions used in the GCPy environment; Also update GitHub actions to avoid deprecation warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +64,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -77,6 +77,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `gcpy/benchmark/modules/emission_species.yml` file with emission species for GEOS-Chem 14.5.0
 - Updated `gcpy/benchmark/modules/benchmark_categories.yml` with the latest categories for GEOS-Chem 14.5.0
 - Updated `gcpy/benchmark/modules/lumped_species.yml` with speciations for GEOS-Chem 14.5.0 
+- Updated `checkout` GitHub action to v4
+- Updated `CodeQL` GitHub action to v3
+- Updated `publish-python` GitHub action to v5
 
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `checkout` GitHub action to v4
 - Updated `CodeQL` GitHub action to v3
 - Updated `publish-python` GitHub action to v5
+- In environment files `gcpy_environment.yml` and `gcpy_requirements.txt`:
+  - Update `python` to 3.12.0
+  - Update `xesmf` to 0.8.5
+  - Update `esmf` and `esmpy` to 8.6.1
+- In environment files `read_the_docs_environment.yml` and `read_the_docs_requirements.txt`
+  - Update `jinja` to 3.1.4 (fixes a security issue)
+- Update `gcpy/setup.py` with the new Python package version numbers
 
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
@@ -87,7 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Import error in `gcpy/examples/diagnostics/compare_diags.py`
 - Added missing `n_cores` to `gcpy/examples/diagnostics/compare_diags.yml`
 - Added missing `plot_drydep` option to `gcpy/gcpy/benchmark/config/1yr_ch4_benchmark.yml`
-- Add `docs/requirements.txt` symbolic link to `docs/environment_files/read_the_docs_requirements.txt` for RTD builds 
+- Add `docs/requirements.txt` symbolic link to `docs/environment_files/read_the_docs_requirements.txt` for RTD builds
 - `gcpy/file_regrid.py` now tests if `lon_bnds`, `lat_bnds` are in the dataset before trying to drop them
 
 ### Removed

--- a/docs/environment_files/gcpy_environment.yml
+++ b/docs/environment_files/gcpy_environment.yml
@@ -7,37 +7,38 @@
 #
 # $ mamba env create -n gcpy_env --file=/path/to/gcpy/environment.yml
 #
-# These package versions have been proven to work together.
-# See: https://github.com/geoschem/gcpy/issues/284
+# Now updated to use Python 12 and esmf/esmpy 8.6.1 so as to allow
+# installation of GCPy from the Python Package Index (PyPI).
+# See: https://github.com/geoschem/gcpy/issues/326
 # =====================================================================
 name: gcpy_env
 channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - cartopy==0.22.0                 # Geospatial data processing
-  - cf_xarray==0.8.4                # CF conventions for xarray
-  - dask==2023.9.2                  # Parallel library; backend for xarray
+  - cartopy==0.23.0                 # Geospatial data processing
+  - cf_xarray==0.9.1                # CF conventions for xarray
+  - dask==2024.5.2                  # Parallel library; backend for xarray
+  - esmf==8.6.1                     # Earth system modeling framework
+  - esmpy==8.6.1                    # Python wrapper for ESMF
   - gridspec==0.1.0                 # Define Earth System Model grids
-  - ipython==8.15.0                 # Interactive Python (used by Jupyter)
-  - joblib==1.3.2                   # Parallelize python code
+  - ipython==8.25.0                 # Interactive Python (used by Jupyter)
+  - joblib==1.4.2                   # Parallelize python code
   - jupyter==1.0.0                  # Jupyter Notebook
-  - matplotlib==3.8.0               # Creates plots and visualizations
-  - netcdf4==1.6.0                  # Python wrapper for netCDF
-  - netcdf-fortran==4.5.4           # Python wrapper for netCDF-Fortran
-  - numpy==1.26.0                   # Optimized mathematical functions
-  - pandas==2.1.1                   # Tables/timeseries manipulation
-  - pip==23.3                       # Install packages from PyPi
-  - pylint==2.17.5                  # Python linter
+  - matplotlib==3.8.4               # Creates plots and visualizations
+  - netcdf4==1.6.5                  # Python wrapper for netCDF
+  - netcdf-fortran==4.6.1           # Python wrapper for netCDF-Fortran
+  - numpy==1.26.4                   # Optimized mathematical functions
+  - pandas==2.2.2                   # Tables/timeseries manipulation
+  - pip==24.0                       # Install packages from PyPi
+  - pylint==3.2.2                   # Python linter
   - pyproj==3.6.1                   # Python map projections library
-  - python==3.9.18                  # Python language
-  - pypdf==3.17.0                   # PDF utilities (bookmarks, etc.)
-  - requests==2.31.0                # HTTP library
-  - scipy==1.11.2                   # Scientific python package
+  - python==3.12.0                  # Python language
+  - pypdf==4.2.0                    # PDF utilities (bookmarks, etc.)
+  - requests==2.32.3                # HTTP library
+  - scipy==1.13.1                   # Scientific python package
   - sparselt==0.1.3                 # Regridding earth system model data
   - tabulate==0.9.0                 # Pretty-printing for column data
-  - tk==8.6.12                      # Tcl/tk library
-  - xarray==2023.8.0                # Read data from netCDF etc files
-  - esmf==8.1.1                     # Earth system modeling framework
-  - esmpy==8.1.1                    # Python wrapper for ESMF
-  - xesmf==0.5.1                    # Universal regridder
+  - tk==8.6.13                      # Tcl/tk library
+  - xarray==2024.5.0                # Read data from netCDF etc files
+  - xesmf==0.8.5                    # Universal regridder

--- a/docs/environment_files/gcpy_requirements.txt
+++ b/docs/environment_files/gcpy_requirements.txt
@@ -8,29 +8,29 @@
 # These package versions have been proven to work together.
 # See: https://github.com/geoschem/gcpy/issues/284
 # ======================================================================
-cartopy==0.22.0                 # Geospatial data processing
-cf_xarray==0.8.4                # CF conventions for xarray
-dask==2023.9.2                  # Parallel library; backend for xarray
+cartopy==0.23.0                 # Geospatial data processing
+cf_xarray==0.9.1                # CF conventions for xarray
+dask==2024.5.2                  # Parallel library; backend for xarray
+esmf==8.6.1                     # Earth system modeling framework
+esmpy==8.6.1                    # Python wrapper for ESMF
 gridspec==0.1.0                 # Define Earth System Model grids
-ipython==8.15.0                 # Interactive Python (used by Jupyter)
-joblib==1.3.2                   # Parallelize python code
+ipython==8.25.0                 # Interactive Python (used by Jupyter)
+joblib==1.4.2                   # Parallelize python code
 jupyter==1.0.0                  # Jupyter Notebook
-matplotlib==3.8.0               # Creates plots and visualizations
-netcdf4==1.6.0                  # Python wrapper for netCDF
-netcdf-fortran==4.5.4           # Python wrapper for netCDF-Fortran
-numpy==1.26.0                   # Optimized mathematical functions
-pandas==2.1.1                   # Tables/timeseries manipulation
-pip==23.3                       # Install packages from PyPi
-pylint==2.17.5                  # Python linter
+matplotlib==3.8.4               # Creates plots and visualizations
+netcdf4==1.6.5                  # Python wrapper for netCDF
+netcdf-fortran==4.6.1           # Python wrapper for netCDF-Fortran
+numpy==1.26.4                   # Optimized mathematical functions
+pandas==2.2.2                   # Tables/timeseries manipulation
+pip==24.0                       # Install packages from PyPi
+pylint==3.2.2                   # Python linter
 pyproj==3.6.1                   # Python map projections library
-python==3.9.18                  # Python language
-pypdf==3.17.0                   # PDF utilities (bookmarks, etc.)
-requests==2.32.2                # HTTP library
-scipy==1.11.2                   # Scientific python package
+python==3.12.0                  # Python language
+pypdf==4.2.0                    # PDF utilities (bookmarks, etc.)
+requests==2.32.3                # HTTP library
+scipy==1.13.1                   # Scientific python package
 sparselt==0.1.3                 # Regridding earth system model data
 tabulate==0.9.0                 # Pretty-printing for column data
-tk==8.6.12                      # Tcl/tk library
-xarray==2023.8.0                # Read data from netCDF etc files
-esmf==8.1.1                     # Earth system modeling framework
-esmpy==8.1.1                    # Python wrapper for ESMF
-xesmf==0.5.1                    # Universal regridder
+tk==8.6.13                      # Tcl/tk library
+xarray==2024.5.0                # Read data from netCDF etc files
+xesmf==0.8.5                    # Universal regridder

--- a/docs/environment_files/read_the_docs_environment.yml
+++ b/docs/environment_files/read_the_docs_environment.yml
@@ -19,6 +19,6 @@ dependencies:
   - sphinx-autobuild==2021.3.14
   - recommonmark==0.7.1
   - docutils==0.20.1
-  - jinja2==3.1.3
+  - jinja2==3.1.4
 
 

--- a/docs/environment_files/read_the_docs_requirements.txt
+++ b/docs/environment_files/read_the_docs_requirements.txt
@@ -12,6 +12,6 @@ sphinxcontrib-bibtex==2.6.2
 sphinx-autobuild==2021.3.14
 recommonmark==0.7.1
 docutils==0.20.1
-jinja2==3.1.3
+jinja2==3.1.4
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
 
@@ -34,7 +34,7 @@ MICRO = 0
 EXTRA = '' # for alpha (aN), beta (bN), rc (rcN) versions
 
 VERSION = f"{MAJOR}.{MINOR}.{MICRO}{EXTRA}"
-'''
+"""
 #DEV format (using git hash) is intriguing but incompatible with PEP 440
 #No hashes can be used in version field
 DEV = True
@@ -59,13 +59,14 @@ if DEV:
         git_rev = git_rev.decode('ascii') # necessary for Python >= 3
 
         VERSION += ".dev-{}".format(git_rev)
-'''
+"""
 
 def _write_version_file():
 
     fn = os.path.join(os.path.dirname(__file__), 'gcpy', '_version.py')
 
-    version_str = dedent("""
+    version_str = dedent(
+        """
         __version__ = '{}'
         """)
 
@@ -90,41 +91,32 @@ setup(
     packages = find_packages(),
     include_package_data=True,
     install_requires=[
-        "awscli==2.13.39",
-        "cartopy==0.22.0",
-        "cf_xarray==0.8.4",
-        "dask==2023.9.2",
+        "cartopy==0.23.0",
+        "cf_xarray==0.9.1",
+        "dask==2024.5.2",
+        "esmf==8.6.1",
+        "esmpy==8.6.1",
         "gridspec==0.1.0",
-        "ipython==8.15.0",
-        "joblib==1.3.2",
+        "ipython==8.25.0",
+        "joblib==1.4.2",
         "jupyter==1.0.0",
-        "matplotlib==3.8.0",
-        "netcdf4==1.6.0",
-        "netcdf-fortran==4.5.4",
-        "numpy==1.26.0",
-        "pandas==2.1.1",
-        "pip==23.3",
-        "pylint==2.17.5",
+        "matplotlib==3.8.4",
+        "netcdf4==1.6.5",
+        "netcdf-fortran==4.6.1",
+        "numpy==1.26.4",
+        "pandas==2.2.2",
+        "pip==24.0",
+        "pylint==3.2.2",
         "pyproj==3.6.1",
-        "python==3.9.18",
-        "pypdf==3.17.0",
-        "recommonmark==0.7.1",
-        "requests==2.32.0",
-        "scipy==1.11.2",
+        "python==3.12.0",
+        "pypdf==4.2.0",
+        "requests==2.32.3",
+        "scipy==1.13.1",
         "sparselt==0.1.3",
         "tabulate==0.9.0",
-        "tk==8.6.12",
-        "xarray==2023.8.0",
-        "esmf==8.1.1",
-        "esmpy==8.1.1",
-        "xesmf==0.5.1",
-        "docutils==0.16",
-        "jinja2==3.0.3",
-        "sphinx==3.5.4",
-        "sphinx-autoapi==1.9.0",
-        "sphinx-autobuild==2021.3.14",
-        "sphinxcontrib-bibtex==2.2.0",
-        "sphinx_rtd_theme==0.5.2",
+        "tk==8.6.13",
+        "xarray==2024.5.0",
+        "xesmf==0.8.5",
     ],
     classifiers = CLASSIFIERS
 )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to issues #326 and #328.  These issues reported that GCPy installation from the Python Package Index (PyPi) failed due to the `xesmf==0.5.1` package having been de-listed.  We have made the following updates:

1. Updated the `docs/environment_files/gcpy_environment.yml` and `docs/environment_files/gcpy_requirements.txt` to use the following package versions:
  - `python==3.12.0`
  - `xesmf==0.8.5`
  - `esmf==8.6.1`
  - `esmpy==8.6.1`
  -  with corresponding dependencies solved by Mamba.
 
2. Updated the `docs/environment_files/read_the_docs_requirements.yml` and `docs/environment_files/read_the_docs_requirements.txt` to use the following package versions:
  - `jinja2==3.1.4`, this fixes a security issue raised by Dependabot
 
3. Now use more recent GitHub actions to avoid deprecation warnings
  - `checkout@v4`
  -  `CodeQL@v3`
  - ` publish-python@v5`

### Expected changes
This will be a zero-diff update.  I have tested the 1-year benchmark scripts using a new Mamba environment with the updated package versions and all plots/tables were generated properly.

### Related Github Issue
- Closes #326
- Closes #328 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 