### PR TITLE
Update benchmark YAML files with new species for GEOS-Chem 14.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to GCPy will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Updated `gcpy/benchmark/modules/emission_species.yml` file with emission species for GEOS-Chem 14.5.0
+
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
 - Added brackets around `exempt-issue-labels` list in `.github/workflows/stale.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Updated `gcpy/benchmark/modules/emission_species.yml` file with emission species for GEOS-Chem 14.5.0
+- Updated `gcpy/benchmark/modules/benchmark_categories.yml` with the latest categories for GEOS-Chem 14.5.0
+- Updated `gcpy/benchmark/modules/lumped_species.yml` with speciations for GEOS-Chem 14.5.0 
 
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run

--- a/gcpy/benchmark/modules/benchmark_categories.yml
+++ b/gcpy/benchmark/modules/benchmark_categories.yml
@@ -134,16 +134,20 @@ FullChemBenchmark:
       - LIMO
     HCs:
       - ALK4
+      - ALK6
       - BENZ
       - CH4
       - C2H2
       - C2H4
       - C2H6
       - C3H8
+      - C4H6
+      - EBZ
       - PRPE
+      - STYR
+      - TMB
       - TOLU
       - XYLE
-  ROy:
     ROy:
       - H2O2
       - H
@@ -182,6 +186,7 @@ FullChemBenchmark:
     Acids:
       - ACTA
     Aldehydes:
+      - ACR
       - ALD2
       - BALD
       - CH2O
@@ -201,6 +206,7 @@ FullChemBenchmark:
       - GLYC
       - GLYX
       - HCOOH
+      - RCOOH
       - MAP
       - PHEN
       - RCHO

--- a/gcpy/benchmark/modules/emission_species.yml
+++ b/gcpy/benchmark/modules/emission_species.yml
@@ -12,6 +12,9 @@ FullChemBenchmark:
   C2H6: Tg
   C3H8: Tg
   CH2Br2: Tg
+  CH2I2: Tg
+  CH2IBr: Tg
+  CH2ICl: Tg
   CH2O: Tg
   CHBr3: Tg
   CO: Tg
@@ -36,17 +39,24 @@ FullChemBenchmark:
   MEK: Tg
   MENO3: Tg
   MGLY: Tg
+  MOH: Tg
   MTPA: Tg
   MTPO: Tg
   NH3: Tg
   'NO': Tg
   NO2: Tg
+  O3: Tg
   OCPI: Tg
   OCPO: Tg
+  PHEN: Tg
   PRPE: Tg
   RCHO: Tg
   SALA: Tg
+  SALAAL: Tg
+  SALACL: Tg
   SALC: Tg
+  SALCAL: Tg
+  SALCCL: Tg
   SO2: Tg
   SO4: Tg
   SOAP: Tg

--- a/gcpy/benchmark/modules/emission_species.yml
+++ b/gcpy/benchmark/modules/emission_species.yml
@@ -1,4 +1,5 @@
 FullChemBenchmark:
+  ACR: Tg
   ACET: Tg
   ALD2: Tg
   ALK4: Tg
@@ -11,6 +12,7 @@ FullChemBenchmark:
   C2H4: Tg
   C2H6: Tg
   C3H8: Tg
+  C4H6: Tg
   CH2Br2: Tg
   CH2I2: Tg
   CH2IBr: Tg
@@ -37,6 +39,7 @@ FullChemBenchmark:
   LIMO: Tg
   MACR: Tg
   MEK: Tg
+  MVK: Tg
   MENO3: Tg
   MGLY: Tg
   MOH: Tg
@@ -61,6 +64,8 @@ FullChemBenchmark:
   SO4: Tg
   SOAP: Tg
   SOAS: Tg
+  STYR: Tg
+  TMB: Tg
   TOLU: Tg
   XYLE: Tg
   pFe: Tg

--- a/gcpy/benchmark/modules/lumped_species.yml
+++ b/gcpy/benchmark/modules/lumped_species.yml
@@ -108,6 +108,21 @@ NOx:
   OLND: 1
   OLNN: 1
 NOy:
+  ALK4N1: 1
+  ALK4N2: 1
+  APAN: 1
+  APINN: 1
+  AROMPN: 1
+  BPINN: 1
+  BPINON: 1
+  BrNO2: 1
+  BrNO3: 1
+  BUTN: 1
+  BZPAN: 1
+  C96N: 1
+  ClNO2: 1
+  ClNO3: 1
+  ETHN: 1
   ETHLN: 1
   ETNO3: 1
   HNO2: 1
@@ -130,6 +145,7 @@ NOy:
   INO: 1
   INO2B: 1
   INO2D: 1
+  INPB: 1
   INPD: 1
   IONO: 1
   IONO2: 1
@@ -138,6 +154,9 @@ NOy:
   ISOPNOO2: 1
   ITCN: 1
   ITHN: 1
+  LIMN: 1
+  LIMNB: 1
+  LIMPAN: 1
   MACRNO2: 1
   MCRHN: 1
   MCRHNB: 1
@@ -148,6 +167,7 @@ NOy:
   N: 1
   N2O5: 2
   'NO': 1
+  NPHEN: 1
   NO2: 1
   NO3: 1
   NPRNO3: 1
@@ -230,12 +250,26 @@ Ox:
   R4N2: 1
 RO2:
   A3O2: 1
+  ACO3: 1
+  ACRO2: 1
+  ALK4N1: 1
+  ALK4O2: 1
+  APINO2: 1
+  AROMCO3: 1
+  AROMRO2: 1
   ATO2: 1
   B3O2: 1
-  BRO2: 2
+  BENZO2: 1
+  BPINO2: 1
+  BPINOO2: 1
+  BUTO2: 1
+  BZCO3: 1
   C4HVP1: 1
   C4HVP2: 1
+  C96O2: 1
   ETO2: 1
+  ETOO: 1
+  GCO3: 1
   HO2: 1
   HPALD1OO: 1
   HPALD2OO: 1
@@ -260,20 +294,22 @@ RO2:
   ISOPNOO2: 1
   KO2: 1
   LIMO2: 1
+  LIMO3: 1
+  LIMKO2: 1
   MACR1OO: 1
   MACRNO2: 1
   MCROHOO: 1
   MCO3: 1
+  MEKCO3: 1
   MO2: 1
   MVKOHOO: 1
+  OTHRO2: 1
   PIO2: 1
   PO2: 1
   PRN1: 1
   R4N1: 1
   R4O2: 1
   RCO3: 1
-  TRO2: 1
-  XRO2: 1
 SOx:
   SO2: 1
   SO4: 1


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR updates the following benchmark configuration files with the latest species as of GEOS-Chem 14.5.0:
- [gcpy/benchmark/modules/benchmark_categories.yml](https://github.com/geoschem/gcpy/blob/main/gcpy/benchmark/modules/benchmark_categories.yml)
- [gcpy/benchmark/modules/emission_species.yml](https://github.com/geoschem/gcpy/blob/main/gcpy/benchmark/modules/emission_species.yml)
- [gcpy/benchmark/modules/lumped_species.yml](https://github.com/geoschem/gcpy/blob/main/gcpy/benchmark/modules/lumped_species.yml)

This will make sure to include new species into the proper benchmark categories, etc.

### Expected changes
New species will be included in the proper PDF corresponding to its category.  Also units will be properly specified in emissions tables.

### Reference(s)
N/A

### Related Github Issue

- See https://github.com/geoschem/geos-chem/pull/2318

Tagging @msulprizio @lizziel @ktravis213 @kelvinhb