### PR TITLE
Now flag GEOS-Chem Classic/GCHP timers that differ by more than 10% in the benchmark timing tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
 - Added brackets around `exempt-issue-labels` list in `.github/workflows/stale.yml`
+- Now flag differences greater than +/- 10% in benchmark timing table outputs
 
 ## [1.5.0] - 2024-05-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to GCPy will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Changed
+- Changed format of `% diff` column from `12.3e` to `12.3f` in benchmark timing tables 
+
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
 - Added brackets around `exempt-issue-labels` list in `.github/workflows/stale.yml`

--- a/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
@@ -181,6 +181,8 @@ def print_timer(key, ref, dev, ofile):
     if np.abs(ref[key] > 0.0):
         pctdiff = ((dev[key] - ref[key]) / ref[key]) * 100.0
     line = f"{key:<22}  {ref[key]:>18.3f}  {dev[key]:>18.3f}   {pctdiff:>12.3e}"
+    if np.abs(pctdiff) >= 10.0:  # Flag diffs > +/- 10%
+        line += " *"
     print(line, file=ofile)
 
 

--- a/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
@@ -180,7 +180,7 @@ def print_timer(key, ref, dev, ofile):
     pctdiff = np.nan
     if np.abs(ref[key] > 0.0):
         pctdiff = ((dev[key] - ref[key]) / ref[key]) * 100.0
-    line = f"{key:<22}  {ref[key]:>18.3f}  {dev[key]:>18.3f}   {pctdiff:>12.3e}"
+    line = f"{key:<22}  {ref[key]:>18.3f}  {dev[key]:>18.3f}   {pctdiff:>12.3f}"
     if np.abs(pctdiff) >= 10.0:  # Flag diffs > +/- 10%
         line += " *"
     print(line, file=ofile)

--- a/gcpy/benchmark/modules/benchmark_scrape_gchp_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gchp_timers.py
@@ -257,6 +257,8 @@ def print_timer(key, ref, dev, ofile):
         pctdiff = ((dev[key] - ref[key]) / ref[key]) * 100.0
     line = \
         f"{label:<22}  {ref[key]:>18.3f}  {dev[key]:>18.3f}   {pctdiff:>12.3e}"
+    if np.abs(pctdiff) >= 10.0:  # Flag diffs > +/- 10%
+        line += " *"
     print(line, file=ofile)
 
 

--- a/gcpy/benchmark/modules/benchmark_scrape_gchp_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gchp_timers.py
@@ -256,7 +256,7 @@ def print_timer(key, ref, dev, ofile):
     if np.abs(ref[key] > 0.0):
         pctdiff = ((dev[key] - ref[key]) / ref[key]) * 100.0
     line = \
-        f"{label:<22}  {ref[key]:>18.3f}  {dev[key]:>18.3f}   {pctdiff:>12.3e}"
+        f"{label:<22}  {ref[key]:>18.3f}  {dev[key]:>18.3f}   {pctdiff:>12.3f}"
     if np.abs(pctdiff) >= 10.0:  # Flag diffs > +/- 10%
         line += " *"
     print(line, file=ofile)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have updated the `benchmark_scrape_gcclassic_timers.py` and `benchmark_scrape_gchp_timers.py` scripts to flag individual GEOS-Chem Classic and GCHP timers that vary by more than +/- 10%.  This will help us to identify performance bottlenecks much more easily.

### Expected changes
Benchmark timing tables now will contain an asterisk after timers that vary by more than +/- 10%.

GEOS-Chem Classic:
```console
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%% GEOS-Chem Classic Benchmark Timing Information
%%%
%%% Ref = gcc-14.4.2
%%% Dev = gcc-14.4.1
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


Timer                              Ref [s]             Dev [s]         % Diff
-------------------------------------------------------------------------------
GEOS-Chem                        28458.415           21173.062     -2.560e+01 *
HEMCO                             2307.501            2287.382     -8.719e-01
All chemistry                    15052.359            8087.397     -4.627e+01 *
=> Gas-phase chem                 5536.890            5295.887     -4.353e+00
=> Photolysis                     7353.315             691.712     -9.059e+01 *
=> Aerosol chem                   1597.813            1598.909      6.859e-02
=> Linearized chem                  30.455              29.045     -4.630e+00
Transport                         1689.448            1660.802     -1.696e+00
Convection                        2490.201            2413.583     -3.077e+00
Boundary layer mixing             2403.692            2271.712     -5.491e+00
Dry deposition                      51.891              51.624     -5.145e-01
Wet deposition                     774.040             755.015     -2.458e+00
Diagnostics                       2367.490            2446.812      3.350e+00
Unit conversions                  1422.235            1267.408     -1.089e+01 *
```
^^^ note: Ref and Dev were swapped in this output inadvertently, but you get the idea.

GCHP
```console
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%% GCHP Benchmark Timing Information
%%%
%%% Ref = gchp-14.4.2
%%% Dev = gchp-14.4.1
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


GCHPchem Timer                     Ref [s]             Dev [s]         % Diff
-------------------------------------------------------------------------------
GCHPchem                          7017.550            7032.760      2.167e-01
--SetService                         0.280               0.270     -3.571e+00
----generic                          0.000               0.000            nan
--Initialize                        30.660              30.090     -1.859e+00
----INITIALIZE                      30.660              30.090     -1.859e+00
------generic                       12.930              13.140      1.624e+00
--Record                             0.020               0.020      0.000e+00
----generic                          0.010               0.010      0.000e+00
--Run                             6947.260            6981.810      4.973e-01
----GenRunMine                    6947.220            6981.760      4.972e-01
------RUN                         6907.250            6936.510      4.236e-01
--------CP_BFRE                      3.070               3.360      9.446e+00
--------DO_CHEM                   6869.460            6897.840      4.131e-01
----------GC_CONV                  523.710             501.900     -4.165e+00
----------GC_DRYDEP                  8.800               8.770     -3.409e-01
----------GC_EMIS                  184.410             186.890      1.345e+00
----------GC_TURB                  619.830             595.020     -4.003e+00
----------GC_CHEM                 4736.540            4751.700      3.201e-01
----------GC_WETDEP                445.050             468.660      5.305e+00
----------GC_DIAGN                  36.980              37.190      5.679e-01
--------CP_AFTR                      0.010               0.010      0.000e+00
--Finalize                           3.220               3.120     -3.106e+00
----generic                          3.210               3.120     -2.804e+00


Summary                            Ref [s]             Dev [s]         % Diff
-------------------------------------------------------------------------------
All                              25606.259           25584.746     -8.401e-02
--SetService                         1.522               1.430     -6.045e+00
----GCHP                             1.499               1.407     -6.137e+00
------GCHPctmEnv                     0.001               0.001      0.000e+00
------GCHPchem                       0.456               0.450     -1.316e+00
------DYNAMICS                       0.981               0.896     -8.665e+00
----HIST                             0.000               0.000            nan
----EXTDATA                          0.000               0.000            nan
--Initialize                        98.315             104.915      6.713e+00
----GCHP                            69.100              75.827      9.735e+00
------GCHPctmEnv                     0.013               0.013      0.000e+00
------GCHPchem                      61.798              65.188      5.486e+00
------DYNAMICS                       5.680               9.107      6.033e+01 *
----HIST                             7.027               7.170      2.035e+00
----EXTDATA                         21.023              21.338      1.498e+00
--Run                            25502.983           25475.018     -1.097e-01
----EXTDATA                       1067.898            1074.784      6.448e-01
----GCHP                         17065.536           17103.029      2.197e-01
------GCHPctmEnv                    44.852              45.314      1.030e+00
------GCHPchem                   11228.451           11255.168      2.379e-01
------DYNAMICS                    5790.771            5801.109      1.785e-01
----HIST                           142.520             145.059      1.782e+00
--Finalize                           3.292               3.189     -3.129e+00
----GCHP                             3.272               3.175     -2.965e+00
------GCHPctmEnv                     0.005               0.006      2.000e+01 *
------GCHPchem                       3.261               3.163     -3.005e+00
------DYNAMICS                       0.003               0.003      0.000e+00
----HIST                             0.007               0.006     -1.429e+01 *
----EXTDATA                          0.010               0.005     -5.000e+01 *
```
### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue

- See https://github.com/geoschem/geos-chem/issues/2416
