### PR TITLE
Add the DryDep collection to the benchmark summary table, and DryDepVel plots to 1-mon cloud benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Example script `gcpy/examples/hemco/make_hemco_sa_spec.py` (creates the HEMCO standalone configuration file `HEMCO_sa_Spec.rc`)
 - Module `benchmark_gcclassic_stats.py` for scraping statistics from GEOS-Chem Classic cloud benchmarks
+- Dry deposition velocity comparison plots in 1-month cloud benchmarks
 
 ### Changed
 - Changed format of `% diff` column from `12.3e` to `12.3f` in benchmark timing tables 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `gcpy/benchmark/modules/emission_species.yml` file with emission species for GEOS-Chem 14.5.0
 - Updated `gcpy/benchmark/modules/benchmark_categories.yml` with the latest categories for GEOS-Chem 14.5.0
 - Updated `gcpy/benchmark/modules/lumped_species.yml` with speciations for GEOS-Chem 14.5.0 
+- Add `DryDep` to list of collections included in benchmark summary table
 
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run

--- a/gcpy/benchmark/cloud/template.1mo_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1mo_benchmark.yml
@@ -119,7 +119,7 @@ options:
     emis_table: True
     plot_jvalues: True
     plot_aod: True
-    plot_drydep: False #Hotfix (bmy, 06 Feb 2024)
+    plot_drydep: True
     mass_table: True
     mass_accum_table: False
     ops_budget_table: False

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -672,7 +672,7 @@ def run_benchmark_default(config):
                 collections = [
                     'AerosolMass',
                     'Aerosols',
-                    #'DryDep',
+                    'DryDep',
                     'Emissions',
                     'JValues',
                     'Metrics',
@@ -1100,6 +1100,7 @@ def run_benchmark_default(config):
                 collections=[
                     'AerosolMass',
                     'Aerosols',
+                    'DryDep',
                     'Emissions',
                     'JValues',
                     'Metrics',
@@ -1607,6 +1608,7 @@ def run_benchmark_default(config):
                 collections=[
                     'AerosolMass',
                     'Aerosols',
+                    'DryDep',
                     'Emissions',
                     'JValues',
                     'Metrics',


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
The GEOS-Chem `DryDep` collection was restored to all fullchem benchmark simulations in https://github.com/geoschem/geos-chem/pull/2144.  This is the corresponding GCPy PR, which includes 


### Expected changes
The `DryDep` collection will be included in this table:
```console
################################################################################
### Benchmark summary table                                                  ###
###                                                                          ###
### Ref = GCC_ref                                                            ###
### Dev = GCC_dev                                                            ###
################################################################################

-------------------------------------------------------------------------------
AerosolMass: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
Aerosols: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
DryDep: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
Emissions: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
JValues: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
Metrics: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
SpeciesConc: GCC_dev is identical to GCC_ref

-------------------------------------------------------------------------------
StateMet: GCC_dev is identical to GCC_ref
```

If the dry deposition velocities differ, you will see output similar to this:
```console
-------------------------------------------------------------------------------
DryDep: GCC_dev differs from GCC_ref

  Diagnostics that differ
    DryDepVel_ACET
    DryDepVel_ACTA
    DryDepVel_AERI
    DryDepVel_ALD2
    DryDepVel_AONITA
    DryDepVel_AROMP4
    DryDepVel_AROMP5
    DryDepVel_ASOA1
    DryDepVel_ASOA2
    DryDepVel_ASOA3
    DryDepVel_ASOAN
    DryDepVel_ASOG1
    ... and 323 others
```

NOTE: We should merge this once we have both Ref and Dev cloud benchmarks with dry deposition diagnostics turned on.  This should be at 14.5.0-alpha.9.

### Reference(s)
N/A

### Related Github Issue

- See https://github.com/geoschem/geos-chem/pull/2144