### PR TITLE
Replace whitespace in Ref and Dev version labels in benchmarking code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - In environment files `read_the_docs_environment.yml` and `read_the_docs_requirements.txt`
   - Update `jinja` to 3.1.4 (fixes a security issue)
 - Update `gcpy/setup.py` with the new Python package version numbers
+- Updated code in `gcpy/benchmark/modules/` to replace whitespace in Ref and Dev labels with underscores
 
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run

--- a/gcpy/benchmark/modules/benchmark_drydep.py
+++ b/gcpy/benchmark/modules/benchmark_drydep.py
@@ -1,14 +1,13 @@
 """
 Specific utilities for creating plots from GEOS-Chem benchmark simulations.
 """
-import os
 import gc
 import numpy as np
 from gcpy import util
 from gcpy.plot.compare_single_level import compare_single_level
 from gcpy.benchmark.modules.benchmark_utils import \
-    get_lumped_species_definitions, make_output_dir, \
-    pdf_filename, print_sigdiffs, read_ref_and_dev
+    get_common_varnames, make_output_dir, pdf_filename, \
+    print_sigdiffs, read_ref_and_dev
 
 # Suppress numpy divide by zero warnings to prevent output spam
 np.seterr(divide="ignore", invalid="ignore")
@@ -94,6 +93,10 @@ def make_benchmark_drydep_plots(
     if spcdb_dir is None:
         msg = "The spcdb_dir argument has not been specified!"
         raise ValueError(msg)
+
+    # Replace whitespace in the ref and dev labels
+    refstr = util.replace_whitespace(refstr)
+    devstr = util.replace_whitespace(devstr)
 
     # Create directory for plots (if it doesn't exist)
     dst = make_output_dir(

--- a/gcpy/benchmark/modules/benchmark_funcs.py
+++ b/gcpy/benchmark/modules/benchmark_funcs.py
@@ -16,6 +16,7 @@ from tabulate import tabulate
 from gcpy import util
 from gcpy.regrid import create_regridders
 from gcpy.grid import get_troposphere_mask
+from gcpy.util import replace_whitespace
 from gcpy.units import convert_units
 from gcpy.constants import COL_WIDTH, MW_AIR_g, skip_these_vars, TABLE_WIDTH
 from gcpy.plot.compare_single_level import compare_single_level
@@ -154,6 +155,10 @@ def create_total_emissions_table(
         ),
         quiet=True
     )
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # ==================================================================
     # Get the list of emission variables for which we will print totals
@@ -447,6 +452,10 @@ def create_global_mass_table(
         quiet=True
     )
 
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
+
     # ==================================================================
     # Open file for output
     # ==================================================================
@@ -691,6 +700,10 @@ def create_mass_accumulation_table(
         ),
         quiet=True
     )
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # ==================================================================
     # Open file for output
@@ -1031,6 +1044,10 @@ def make_benchmark_conc_plots(
         extra_title_txt = subdst
     else:
         extra_title_txt = None
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # Pick the proper function to read the data
     reader = util.dataset_reader(time_mean, verbose=verbose)
@@ -1710,6 +1727,10 @@ def make_benchmark_emis_plots(
     else:
         extra_title_txt = None
 
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
+
     # Get the function that will read the dataset
     reader = util.dataset_reader(time_mean, verbose=verbose)
 
@@ -2098,6 +2119,10 @@ def make_benchmark_emis_tables(
     if not os.path.isdir(emisdir):
         os.mkdir(emisdir)
 
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
+
     # ==================================================================
     # Read data from netCDF into Dataset objects
     # ==================================================================
@@ -2342,6 +2367,10 @@ def make_benchmark_jvalue_plots(
 
     # Create the directory for output
     util.make_directory(dst, overwrite)
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # Get the function that will read file(s) into a Dataset
     reader = util.dataset_reader(time_mean, verbose=verbose)
@@ -2727,6 +2756,10 @@ def make_benchmark_aod_plots(
     else:
         extra_title_txt = None
 
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
+
     # Get the function that will read file(s) into a dataset
     reader = util.dataset_reader(time_mean, verbose=verbose)
 
@@ -3009,10 +3042,18 @@ def make_benchmark_mass_tables(
             which do not contain the Area variable.
             Default value: ''
     """
+    # ==================================================================
+    # Initialization
+    # ==================================================================
+
     # Make sure the species database folder is passed
     if spcdb_dir is None:
         msg = "The 'spcdb_dir' argument has not been specified!"
         raise ValueError(msg)
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # ==================================================================
     # Define destination directory
@@ -3275,10 +3316,18 @@ def make_benchmark_mass_accumulation_tables(
             Directory of species_datbase.yml file
             Default value: None
     """
+    # ==================================================================
+    # Initialization
+    # ==================================================================
+
     # Make sure the species database folder is passed
     if spcdb_dir is None:
         msg = "The 'spcdb_dir' argument has not been specified!"
         raise ValueError(msg)
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # ==================================================================
     # Define destination directory
@@ -3543,9 +3592,15 @@ def make_benchmark_oh_metrics(
     """
 
     # ==================================================================
-    # Define destination directory
+    # Initialization
     # ==================================================================
+
+    # Define destination directory
     util.make_directory(dst, overwrite)
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # ==================================================================
     # Read data from netCDF into Dataset objects
@@ -3832,6 +3887,10 @@ def make_benchmark_wetdep_plots(
         targetdst = os.path.join(targetdst, datestr)
         if not os.path.isdir(targetdst):
             os.mkdir(targetdst)
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # Get the function that will read file(s) into a dataset
     reader = util.dataset_reader(time_mean, verbose=verbose)
@@ -4388,6 +4447,9 @@ def make_benchmark_operations_budget(
             Directory containing the species_database.yml file.
             Default value: None
     """
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # ------------------------------------------
     # Column sections
@@ -5082,6 +5144,10 @@ def create_benchmark_summary_table(
     # ==================================================================
     # Open file for output
     # ==================================================================
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # Create the directory for output
     util.make_directory(dst, overwrite)

--- a/gcpy/benchmark/modules/benchmark_gcclassic_stats.py
+++ b/gcpy/benchmark/modules/benchmark_gcclassic_stats.py
@@ -9,7 +9,7 @@ $ python -m gcpy.benchmark.modules.benchmark_scrape_gcclassic_stats 14.5.0-alpha
 """
 import sys
 import requests
-from gcpy.util import verify_variable_type
+from gcpy.util import replace_whitespace, verify_variable_type
 
 # ----------------------------------------------------------------------
 # Global variables
@@ -113,7 +113,7 @@ def scrape_stats(text):
             stats["CH3CCl3"] = line.split(":")[1].strip()
         if line_count == 18 and "Dev" in line:
             stats["Mean OH"] = line.split(":")[1].strip()
-            
+
         # Skip commands
         if "++ sed" in line:
             line_count += 1
@@ -167,6 +167,10 @@ def main(ref_label, dev_label):
     """
     verify_variable_type(ref_label, str)
     verify_variable_type(dev_label, str)
+
+    # Replace whitespace in the ref and dev labels
+    ref_label = replace_whitespace(ref_label)
+    dev_label = replace_whitespace(dev_label)
 
     # Scrape the log file text into a variable
     bmk_id = f"gcc-4x5-1Mon-{dev_label}"

--- a/gcpy/benchmark/modules/benchmark_mass_cons_table.py
+++ b/gcpy/benchmark/modules/benchmark_mass_cons_table.py
@@ -9,8 +9,8 @@ import xarray as xr
 from gcpy.constants import skip_these_vars
 from gcpy.units import convert_units
 from gcpy.util import \
-    replace_whitespace, dataset_reader, get_area_from_dataset, \
-    make_directory, read_config_file, verify_variable_type
+    dataset_reader, get_area_from_dataset, make_directory, \
+    read_config_file, replace_whitespace, verify_variable_type
 from gcpy.benchmark.modules.benchmark_utils import \
     get_datetimes_from_filenames
 
@@ -316,6 +316,10 @@ def make_benchmark_mass_conservation_table(
 
     # Create the destination folder
     make_directory(dst, overwrite)
+
+    # Replace whitespace in the ref and dev labels
+    ref_label = replace_whitespace(ref_label)
+    dev_label = replace_whitespace(dev_label)
 
     # Get a list of properties for the given species
     metadata = get_passive_tracer_metadata(spcdb_dir)

--- a/gcpy/benchmark/modules/benchmark_models_vs_obs.py
+++ b/gcpy/benchmark/modules/benchmark_models_vs_obs.py
@@ -21,7 +21,8 @@ import pandas as pd
 import numpy as np
 import xarray as xr
 from gcpy.constants import skip_these_vars
-from gcpy.util import verify_variable_type, dataset_reader, make_directory
+from gcpy.util import \
+    dataset_reader, make_directory, replace_whitespace, verify_variable_type
 from gcpy.cstools import extract_grid
 from gcpy.grid import get_nearest_model_data
 from gcpy.benchmark.modules.benchmark_utils import \
@@ -50,6 +51,11 @@ def read_nas(
 
     if verbose:
         print(f"read_nas: Reading {input_file}")
+
+    # Initialize
+    lon = 0.0
+    lat = 0.0
+    alt = 0.0
 
     with open(input_file, encoding='UTF-8') as the_file:
         header = np.array(
@@ -113,11 +119,11 @@ def read_nas(
         index=obs_dataframe.index
     )
     obs_site_coords = { site:
-          {
-              'lon': lon,
-              'lat': lat,
-              'alt': alt
-          }
+        {
+            'lon': lon,
+            'lat': lat,
+            'alt': alt
+        }
     }
 
     return obs_dataframe, obs_site_coords
@@ -194,13 +200,12 @@ def read_model_data(
     Returns
     dataarray : xr.DataArray : GEOS-Chem data read from disk
     """
-
     # Read the Ref and Dev model data
     reader = dataset_reader(
         multi_files=True,
         verbose=verbose,
     )
-    
+
     # Read data and rename SpeciesConc_ to SpeciesConcVV_, if necessary
     # (needed for backwards compatibility with older versions.)
     dataset = reader(filepaths,drop_variables=skip_these_vars).load()
@@ -754,6 +759,10 @@ def make_benchmark_models_vs_obs_plots(
     verify_variable_type(ref_label, str)
     verify_variable_type(dev_filepaths, (str, list))
     verify_variable_type(dev_label, str)
+
+    # Replace whitespace in the ref and dev labels
+    ref_label = replace_whitespace(ref_label)
+    dev_label = replace_whitespace(dev_label)
 
     # Create the destination folder
     make_directory(

--- a/gcpy/benchmark/modules/benchmark_models_vs_sondes.py
+++ b/gcpy/benchmark/modules/benchmark_models_vs_sondes.py
@@ -11,7 +11,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
 from gcpy.cstools import extract_grid
 from gcpy.grid import get_nearest_model_data, get_vert_grid
-from gcpy.util import make_directory, verify_variable_type
+from gcpy.util import make_directory, replace_whitespace, verify_variable_type
 from gcpy.benchmark.modules.benchmark_utils import \
     read_ref_and_dev, rename_speciesconc_to_speciesconcvv
 
@@ -521,6 +521,10 @@ def make_benchmark_models_vs_sondes_plots(
     verify_variable_type(ref_label, str)
     verify_variable_type(dev_filepaths, (str, list))
     verify_variable_type(dev_label, str)
+
+    # Replace whitespace in the ref and dev labels
+    ref_label = replace_whitespace(ref_label)
+    dev_label = replace_whitespace(dev_label)
 
     # Create the destination folder
     make_directory(

--- a/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
@@ -261,6 +261,10 @@ def make_benchmark_gcclassic_timing_table(
     # Create the destination folder
     make_directory(dst, overwrite)
 
+    # Replace whitespace in the ref and dev labels
+    ref_label = replace_whitespace(ref_label)
+    dev_label = replace_whitespace(dev_label)
+
     # Strip timing info from JSON/text file(s) and sum the them.
     ref_timers = sum_timers(read_gcclassic(ref_files))
     dev_timers = sum_timers(read_gcclassic(dev_files))

--- a/gcpy/benchmark/modules/benchmark_scrape_gchp_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gchp_timers.py
@@ -331,6 +331,10 @@ def make_benchmark_gchp_timing_table(
     # Create the destination folder
     make_directory(dst, overwrite)
 
+    # Replace whitespace in the ref and dev labels
+    ref_label = replace_whitespace(ref_label)
+    dev_label = replace_whitespace(dev_label)
+
     # Strip timing info from JSON/text file(s) and sum the them.
     ref_timers = sum_timers(read_timing_data(ref_files))
     dev_timers = sum_timers(read_timing_data(dev_files))

--- a/gcpy/benchmark/modules/budget_ox.py
+++ b/gcpy/benchmark/modules/budget_ox.py
@@ -10,15 +10,16 @@ or GCHP benchmark simulations.
 import os
 import warnings
 from calendar import monthrange
+import gc
 import numpy as np
 import xarray as xr
-import gcpy.constants as constants
+from gcpy import constants
 from gcpy.grid import get_troposphere_mask
 from gcpy.util import get_filepath, read_config_file, \
-    rename_and_flip_gchp_rst_vars, reshape_MAPL_CS
+    rename_and_flip_gchp_rst_vars, reshape_MAPL_CS, \
+    replace_whitespace
 from gcpy.benchmark.modules.benchmark_utils import \
     add_lumped_species_to_dataset, get_lumped_species_definitions
-import gc
 
 # Suppress harmless run-time warnings (mostly about underflow in division)
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -75,7 +76,7 @@ class _GlobVars:
         # --------------------------------------------------------------
         # Arguments from outside
         # --------------------------------------------------------------
-        self.devstr = devstr
+        self.devstr = replace_whitespace(devstr)
         self.devdir = devdir
         self.devrstdir = devrstdir
         self.dst = dst
@@ -362,7 +363,7 @@ def init_and_final_mass(
     g100 = 100.0 / constants.G
     airmass_ini = (deltap_ini * globvars.area_m2.values) * g100
     airmass_end = (deltap_end * globvars.area_m2.values) * g100
-    
+
     # Conversion factors
     mw_ratio = globvars.mw["O3"] / globvars.mw["Air"]
     kg_to_tg = 1.0e-9
@@ -466,11 +467,11 @@ def annual_average_drydep(
     mw_avo = (globvars.mw["Ox"] / constants.AVOGADRO)
     kg_to_tg = 1.0e-9
     area_cm2 = globvars.area_cm2.values
-    
+
     # Get drydep flux of Ox [molec/cm2/s]
     dry = globvars.ds_dry["DryDep_Ox"].values
 
-    # Convert to Tg Ox 
+    # Convert to Tg Ox
     dry_tot = 0.0
     for t in range(globvars.N_MONTHS):
         dry_tot += np.nansum(dry[t, :, :] * area_cm2) * globvars.frac_of_a[t]

--- a/gcpy/benchmark/modules/budget_tt.py
+++ b/gcpy/benchmark/modules/budget_tt.py
@@ -10,17 +10,16 @@ TransportTracersBenchmark simulations.
 # ======================================================================
 
 import os
-from glob import glob
 import warnings
 from calendar import monthrange
+import gc
 import numpy as np
 import xarray as xr
-import gcpy.constants as constants
+from gcpy import constants
 from gcpy.grid import get_troposphere_mask
-import gcpy.util as util
+from gcpy import util
 from gcpy.benchmark.modules.benchmark_utils import \
     rename_speciesconc_to_speciesconcvv
-import gc
 
 # Suppress harmless run-time warnings (mostly about underflow in division)
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -67,7 +66,7 @@ class _GlobVars:
         # ------------------------------
         # Arguments from outside
         # ------------------------------
-        self.devstr = devstr
+        self.devstr = util.replace_whitespace(devstr)
         self.devdir = devdir
         self.devrstdir = devrstdir
         self.dst = dst

--- a/gcpy/benchmark/modules/oh_metrics.py
+++ b/gcpy/benchmark/modules/oh_metrics.py
@@ -15,7 +15,7 @@ import warnings
 import numpy as np
 import xarray as xr
 import gcpy.constants as const
-from gcpy.util import make_directory, read_config_file
+from gcpy.util import make_directory, read_config_file, replace_whitespace
 
 # =====================================================================
 # %%% METHODS %%%
@@ -219,7 +219,6 @@ def init_common_vars(ref, refstr, dev, devstr, spcdb_dir):
     Returns:
         common_vars: dict
     """
-
     # Get species database
     spcdb = read_config_file(
         os.path.join(
@@ -469,6 +468,10 @@ def make_benchmark_oh_metrics(
     # Make sure the species database folder is passed
     if spcdb_dir is None:
         raise ValueError("The 'spcdb_dir' argument has not been specified!")
+
+    # Replace whitespace in the ref and dev labels
+    refstr = replace_whitespace(refstr)
+    devstr = replace_whitespace(devstr)
 
     # Tell matplotlib not to look for an X-window
     os.environ["QT_QPA_PLATFORM"] = "offscreen"

--- a/gcpy/benchmark/modules/ste_flux.py
+++ b/gcpy/benchmark/modules/ste_flux.py
@@ -59,7 +59,7 @@ class _GlobVars:
         # ------------------------------
         # Arguments from outside
         # ------------------------------
-        self.devstr = devstr
+        self.devstr = util.replace_whitespace(devstr)
         self.files = files
         self.dst = dst
         self.overwrite = overwrite


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to #316.  We have updated the benchmarking codes in `gcpy/benchmark/modules/*` (as described in commit cbee385ea4934da04c8897399e8d5ff305500e77) so that we now call the `util.replace_whitespace` function on the Ref and Dev version labels and in output file names.

We have also made minor changes (trimming whitespace, etc) suggested by Pylint.

### Expected changes
If a user specifies e.g. version labels such as:
```yaml
data:
  ref:
    gcc:
      version: gcc 14.2.0 rc 0
      ...
    gchp:
      version: gchp 14.2.0 rc 0
  ...
  dev:
    gcc:
      version: gcc 14.2.0 rc 2
      ...
    gchp:
      version: gchp 14.2.0 rc 2
```
then these will be printed out as
```console
gcc_14.2.0_rc_0
gchp_14.2.0_rc_0
gcc_14.2.0_rc_2
gchp_14.2.0_rc.2
```

### Related Github Issue

- Closes #316 