### PR TITLE
Use ALK6 species name for >= C6 alkanes instead of ALK7

### DIFF
--- a/gcpy/benchmark/modules/benchmark_categories.yml
+++ b/gcpy/benchmark/modules/benchmark_categories.yml
@@ -1,3 +1,4 @@
+
 FullChemBenchmark:
   Aerosols:
     Dust:
@@ -134,7 +135,7 @@ FullChemBenchmark:
       - LIMO
     HCs:
       - ALK4
-      - ALK7
+      - ALK6
       - BENZ
       - CH4
       - C2H2

--- a/gcpy/benchmark/modules/emission_species.yml
+++ b/gcpy/benchmark/modules/emission_species.yml
@@ -3,7 +3,7 @@ FullChemBenchmark:
   ACET: Tg
   ALD2: Tg
   ALK4: Tg
-  ALK7: Tg
+  ALK6: Tg
   BCPI: Tg
   BCPO: Tg
   BENZ: Tg


### PR DESCRIPTION
### Name and Institution (Required)

Name: Melissa Sulprizio
Institution: Harvard

### Describe the update

For consistency with the literature (e.g. Travis et al, EGUsphere, 2024) we rename ALK7 to ALK6.

This should be merged in at the same time as https://github.com/geoschem/geos-chem/pull/2493.

### Expected changes

This is a zero difference update w/r/t plotting. It simply changes a species name.