### PR TITLE
Fix computation of dynamic ratio colorbar min/max values in six_plot.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
 - Now flag differences greater than +/- 10% in benchmark timing table outputs
+- Fixed error in computation of dynamic ratio plot min & max values in `plot/six_plot.py`
 
 ### Removed
 - Removed `gcpy/benchmark/modules/species_database.yml` file and corresponding code pointing to this

--- a/gcpy/plot/six_plot.py
+++ b/gcpy/plot/six_plot.py
@@ -544,10 +544,10 @@ def vmin_vmax_for_ratio_plots(
     """
     # Ratio (dynamic range) subplot)
     if subplot in "dyn_ratio":
-        vmax = np.max(
+        vmin = np.min(
             [np.abs(np.nanmin(plot_val)), np.abs(np.nanmax(plot_val))]
         )
-        vmin = 1.0 / vmax
+        vmax = 1.0 / vmin
         if vmin > vmax:
             vmin, vmax = vmax, vmin
         verbose_print(verbose, rowcol, vmin, vmax)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes an issue with the computation of the dynamic range colorbar values.  Under certain circumstances the colorbar range would be set to a narrower range than what the actual data showed.  Case in point, this J-value plot at 500 hPa from the 14.5.0-alpha.17 vs. 14.4.3 GEOS-Chem benchmark plots.

![jval_bad](https://github.com/user-attachments/assets/ffd97de3-e14c-4c31-bec7-8f391b9d384f)

### Expected changes
With this fix, the dynamic range colorbar ratio is set to the proper range to capture the variation in the data.
![jval_fixed](https://github.com/user-attachments/assets/c3328056-cc9f-41a1-ba7d-2236778e245f)
