### PR TITLE
Fix incorrect species classification in benchmark_categories.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed formatting error in `.github/workflows/stale.yml` that caused the Mark Stale Issues action not to run
 - Now flag differences greater than +/- 10% in benchmark timing table outputs
 - Fixed error in computation of dynamic ratio plot min & max values in `plot/six_plot.py`
+- Fixed erroneous species classification in `gcpy/benchmark/modules/benchmark_categories.yml`
 
 ### Removed
 - Removed `gcpy/benchmark/modules/species_database.yml` file and corresponding code pointing to this

--- a/gcpy/benchmark/modules/benchmark_categories.yml
+++ b/gcpy/benchmark/modules/benchmark_categories.yml
@@ -70,7 +70,7 @@ FullChemBenchmark:
       - HCl
       - Halons
       - HCFCs
-      - OClO    
+      - OClO
   Iodine:
     Iodine:
       - Iy
@@ -122,7 +122,7 @@ FullChemBenchmark:
       - O3
       - CO
       - OH
-      - NOx    
+      - NOx
   Primary_Organics:
     Alcohols:
       - EOH
@@ -186,13 +186,20 @@ FullChemBenchmark:
   Secondary_Organics:
     Acids:
       - ACTA
+      - HACTA
+      - HCOOH
+      - MAP
+      - RCOOH
     Aldehydes:
       - ACR
       - ALD2
       - BALD
       - CH2O
+      - GLYC
+      - GLYX
       - HPALDs
       - MACR
+      - RCHO
     Epoxides:
       - IEPOX
     Ketones:
@@ -204,13 +211,8 @@ FullChemBenchmark:
       - ISOPN
     Other:
       - FURA
-      - GLYC
-      - GLYX
-      - HCOOH
-      - RCOOH
-      - MAP
       - PHEN
-      - RCHO
+      - TLFUONE
     Peroxides:
       - ETHP
       - MP


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes some incorrect species clarifications in the `gcpy.benchmark.modules.benchmark_categories.yml`.  This YAML file determines how species are grouped into different PDFs (for the `SpeciesConcVV` plots only).

Based on feedback from @ktravis213 we have made the following updates:
- Moved HACTA, HCOOH, MAP, RCOOH to `Secondary_Organics:Acids`
- Moved GLYC, GLYX, RCHO to `Secondary_Organics:Aldehydes`
- Added TLFUONE to `Secondary_Organics:Other`

### Expected changes
This will now place the affected species in the proper PDF file.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue

- https://github.com/geoschem/geos-chem/pull/2318

Tagging @ktravis213 @kelvinhb