### PR TITLE
Fix type errors in calc_rectilinear_lon_edge and calc_rectilinear_lat_edge in grid.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Now flag differences greater than +/- 10% in benchmark timing table outputs
 - Fixed error in computation of dynamic ratio plot min & max values in `plot/six_plot.py`
 - Fixed erroneous species classification in `gcpy/benchmark/modules/benchmark_categories.yml`
+- Fixed type errors in `calc_rectilinear_lon_edge` and `calc_rectangular_lat_edge` by casting the length of the output   array from `float` to `int`
 
 ### Removed
 - Removed `gcpy/benchmark/modules/species_database.yml` file and corresponding code pointing to this

--- a/gcpy/grid.py
+++ b/gcpy/grid.py
@@ -949,7 +949,9 @@ def make_grid_SG(csres, stretch_factor, target_lon, target_lat):
 
 
 def calc_rectilinear_lon_edge(lon_stride, center_at_180):
-    """ Compute longitude edge vector for a rectilinear grid.
+    """
+    Compute longitude edge vector for a rectilinear grid.
+
     Parameters
     ----------
     lon_stride: float
@@ -959,26 +961,20 @@ def calc_rectilinear_lon_edge(lon_stride, center_at_180):
         Whether or not the grid should have a cell center at 180 degrees (i.e.
         on the date line). If true, the first grid cell is centered on the date
         line; if false, the first grid edge is on the date line.
+
     Returns
     -------
     Longitudes of cell edges in degrees East.
+
     Notes
     -----
     All values are forced to be between [-180,180]. For a grid with N cells in
     each band, N+1 edges will be returned, with the first and last value being
     duplicates.
-    Examples
-    --------
-    >>> from gcpy.grid.horiz import calc_rectilinear_lon_edge
-    >>> calc_rectilinear_lon_edge(5.0,true)
-    np.array([177.5,-177.5,-172.5,...,177.5])
-    See Also
-    --------
-    [NONE]
     """
 
-    n_lon = np.round(360.0 / lon_stride)
-    lon_edge = np.linspace(-180.0, 180.0, num=n_lon + 1)
+    n_lon_edge = int(np.round(360.0 / lon_stride)) + 1
+    lon_edge = np.linspace(-180.0, 180.0, num=n_lon_edge)
     if center_at_180:
         lon_edge = lon_edge - (lon_stride / 2.0)
 
@@ -989,7 +985,9 @@ def calc_rectilinear_lon_edge(lon_stride, center_at_180):
 
 
 def calc_rectilinear_lat_edge(lat_stride, half_polar_grid):
-    """ Compute latitude edge vector for a rectilinear grid.
+    """
+    Compute latitude edge vector for a rectilinear grid.
+
     Parameters
     ----------
     lat_stride: float
@@ -1000,22 +998,16 @@ def calc_rectilinear_lat_edge(lat_stride, half_polar_grid):
         half the size). In either case the grid will start and end at -/+ 90,
         but when half_polar_grid is True, the first and last bands will have a
         width of 1/2 the normal lat_stride.
+
     Returns
     -------
     Latitudes of cell edges in degrees North.
+
     Notes
     -----
     All values are forced to be between [-90,90]. For a grid with N cells in
     each band, N+1 edges will be returned, with the first and last value being
     duplicates.
-    Examples
-    --------
-    >>> from gcpy.grid.horiz import calc_rectilinear_lat_edge
-    >>> calc_rectilinear_lat_edge(4.0,true)
-    np.array([-90,-88,-84,-80,...,84,88,90])
-    See Also
-    --------
-    [NONE]
     """
 
     if half_polar_grid:
@@ -1023,8 +1015,9 @@ def calc_rectilinear_lat_edge(lat_stride, half_polar_grid):
     else:
         start_pt = 90.0
 
-    lat_edge = np.linspace(-1.0 * start_pt, start_pt,
-                           num=1 + np.round(2.0 * start_pt / lat_stride))
+    n_lat_edge = int(np.round(2.0 * start_pt / lat_stride)) + 1
+
+    lat_edge = np.linspace(-1.0 * start_pt, start_pt, num=n_lat_edge)
 
     # Force back onto +/- 90
     lat_edge[lat_edge > 90.0] = 90.0
@@ -1034,22 +1027,17 @@ def calc_rectilinear_lat_edge(lat_stride, half_polar_grid):
 
 
 def calc_rectilinear_grid_area(lon_edge, lat_edge):
-    """ Compute grid cell areas (in m2) for a rectilinear grid.
+    """
+    Compute grid cell areas (in m2) for a rectilinear grid.
+
     Parameters
     ----------
-    #TODO
+    lon_edge : float : Grid box longitude edges (in degrees north)
+    lat_edge : float : Grid box latitude edges (in degrees east)
+
     Returns
     -------
-    #TODO
-    Notes
-    -----
-    #TODO
-    Examples
-    --------
-    #TODO
-    See Also
-    --------
-    [NONE]
+    area     : float : Array of grid box areas in m2.
     """
 
     # Convert from km to m


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes type errors in routines to compute the lon & lat edges of rectilinear grids (in `gcpy/grid.py`).  Running this test program:
```python
#!/usr/bin/env python3

import numpy as np
import gcpy

# Longitude parameters
lon_stride = 0.25
center_at_180 = True

# Latitude parameters
lat_stride = 0.3125
half_polar_grid = True

# Grid box lon & lat edges
lon_edge = gcpy.grid.calc_rectilinear_lon_edge(lon_stride, center_at_180)
lat_edge = gcpy.grid.calc_rectilinear_lat_edge(lat_stride, half_polar_grid)

# Grid box area
area = gcpy.grid.calc_rectilinear_grid_area(lon_edge, lat_edge)

print(f"Sum of global surface area [m2]: {np.sum(area)}")
```
currently results in these errors:
```console
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/n/home09/ryantosca/test/python/grid.py", line 15, in <module>
    lon_edge = gcpy.grid.calc_rectilinear_lon_edge(lon_stride, center_at_180)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/n/home09/ryantosca/python/gcpy/gcpy/grid.py", line 981, in calc_rectilinear_lon_edge
    lon_edge = np.linspace(-180.0, 180.0, num=n_lon + 1)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/n/jacob_lab/Users/ryantosca/mamba/envs/test_env/lib/python3.12/site-packages/numpy/core/function_base.py", line 122, in linspace
    num = operator.index(num)


Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/n/home09/ryantosca/test/python/grid.py", line 16, in <module>
    lat_edge = gcpy.grid.calc_rectilinear_lat_edge(lat_stride, half_polar_grid)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/n/home09/ryantosca/python/gcpy/gcpy/grid.py", line 1026, in calc_rectilinear_lat_edge
    lat_edge = np.linspace(-1.0 * start_pt, start_pt,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/n/jacob_lab/Users/ryantosca/mamba/envs/test_env/lib/python3.12/site-packages/numpy/core/function_base.py", line 122, in linspace
    num = operator.index(num)
```
This is because the `num` arguments that are passed to NumPy routine `np.linspace` within these routines are of type `float` rather than the expected `int`.  The solution is to cast these to `int`.

### Expected changes
After the fix, the program works as expected and prints
```console
Sum of global surface area [m2]: 510065624779438.94
```

NOTE: These routines are not used in the benchmarking code but are user utilities.

### Related Github Issue
- See https://github.com/geoschem/HEMCO/issues/301