### PR TITLE
Bump jinja2 to 3.1.5 as suggested by Dependabot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Update `xesmf` to 0.8.5
   - Update `esmf` and `esmpy` to 8.6.1
 - In environment files `read_the_docs_environment.yml` and `read_the_docs_requirements.txt`
-  - Update `jinja` to 3.1.4 (fixes a security issue)
+  - Update `jinja` to 3.1.5 (fixes a security issue)
 - Update `gcpy/setup.py` with the new Python package version numbers
 - Updated code in `gcpy/benchmark/modules/` to replace whitespace in Ref and Dev labels with underscores
 

--- a/docs/environment_files/read_the_docs_environment.yml
+++ b/docs/environment_files/read_the_docs_environment.yml
@@ -19,6 +19,6 @@ dependencies:
   - sphinx-autobuild==2021.3.14
   - recommonmark==0.7.1
   - docutils==0.20.1
-  - jinja2==3.1.4
+  - jinja2==3.1.5
 
 

--- a/docs/environment_files/read_the_docs_requirements.txt
+++ b/docs/environment_files/read_the_docs_requirements.txt
@@ -12,6 +12,6 @@ sphinxcontrib-bibtex==2.6.2
 sphinx-autobuild==2021.3.14
 recommonmark==0.7.1
 docutils==0.20.1
-jinja2==3.1.4
+jinja2==3.1.5
 
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have updated the version of jinja2 (needed for ReadTheDocs) from 3.1.4 to 3.1.5, to fix a securityissue.  This was suggested by the GitHub Dependabot service.

### Expected changes
This is a zero-diff update.  It only affects the Python packages used for ReadTheDocs.

### Related Github Issue
- Closes https://github.com/geoschem/gcpy/security/dependabot/23
- Closes https://github.com/geoschem/gcpy/security/dependabot/22
- Closes https://github.com/geoschem/gcpy/security/dependabot/20
- Closes https://github.com/geoschem/gcpy/security/dependabot/19