### PR TITLE
Update default paths to regridding weights in YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Updated paths to regridding weights in `benchmark/config/*.yml` and `examples/diagnostics/compare_diags.yml` files
+
 ## [1.6.0] - 2025-01-29
 ### Added
 - Added example script `gcpy/examples/hemco/make_hemco_sa_spec.py` (creates the HEMCO standalone configuration file `HEMCO_sa_Spec.rc`)

--- a/gcpy/benchmark/config/1mo_benchmark.yml
+++ b/gcpy/benchmark/config/1mo_benchmark.yml
@@ -28,7 +28,7 @@
 paths:
   main_dir: /path/to/benchmark/main/dir
   results_dir: /path/to/BenchmarkResults
-  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
+  weights_dir: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
 #
 # data: Contains configurations for ref and dev runs

--- a/gcpy/benchmark/config/1yr_ch4_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_ch4_benchmark.yml
@@ -28,7 +28,7 @@
 paths:
   main_dir: /path/to/benchmark/main/dir    # EDIT AS NEEDED
   results_dir: /path/to/BenchmarkResults   # EDIT AS NEEDED
-  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
+  weights_dir: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
   #
   # Observational data dirs are on Harvard Cannon, edit if necessary

--- a/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
@@ -29,7 +29,7 @@
 paths:
   main_dir: /path/to/benchmark/main/dir
   results_dir: /path/to/BenchmarkResults
-  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
+  weights_dir: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
   #
   # Observational data dirs are on Harvard Cannon, edit if necessary

--- a/gcpy/benchmark/config/1yr_tt_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_tt_benchmark.yml
@@ -29,7 +29,7 @@
 paths:
   main_dir: /path/to/benchmark/main/dir
   results_dir: /path/to/BenchmarkResults
-  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/data/ExtData/GCHP/RegriddingWeights
+  weights_dir: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
   spcdb_dir: default
 #
 # data: Contains configurations for ref and dev runs

--- a/gcpy/examples/diagnostics/compare_diags.yml
+++ b/gcpy/examples/diagnostics/compare_diags.yml
@@ -2,7 +2,7 @@
 paths:
   main_dir: /path/to/your/data   # Add the path to your output here
   plots_dir: ./Results
-  weights_dir: /n/holyscratch01/external_repos/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
+  weights_dir: /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
 
 data:
   ref:


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR updates the default paths (for the Harvard Cannon cluster) to the regridding weights in the `gcpy/benchmark/config/*.yml` files and the `gcpy/examples/diagnostics/compare_diags.yml` file.

Old path:
- /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights
- This path was deactivated in February 2025

New path:
- /n/holylfs06/LABS/jacob_lab/Shared/GEOS-CHEM/gcgrid/gcdata/ExtData/GCHP/RegriddingWeights

### Expected changes
This is a zero-diff update.