### PR TITLE
Update to dask 2025.3.0 and jinja2 3.1.6 to fix security issues identified by dependabot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renamed GitHub Actions config file `.github/workflows/build-gcpy-environment.yml` to `build-gcpy-environment-py312.yml`
 - Updated package version information in ReadTheDocs documentation
 - Bumped dask from version 2024.5.2 to 2025.3.0 to fix a security issue (raised by @dependabot)
+- Bumped jinja2 from version 3.1.5 to 3.1.6 to fix a security issue (raised by @dependabot)
 
 ### Removed
 - Removed PyPi configuration file  `docs/environment_files/gcpy_requirements.txt` and symbolic link `./requirements.txt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated symbolic link `environment.yml` to point to `docs/source/gcpy_environment_py312.yml`
 - Renamed GitHub Actions config file `.github/workflows/build-gcpy-environment.yml` to `build-gcpy-environment-py312.yml`
 - Updated package version information in ReadTheDocs documentation
+- Bumped dask from version 2024.5.2 to 2025.3.0 to fix a security issue (raised by @dependabot)
 
 ### Removed
 - Removed PyPi configuration file  `docs/environment_files/gcpy_requirements.txt` and symbolic link `./requirements.txt`

--- a/docs/environment_files/gcpy_environment_py312.yml
+++ b/docs/environment_files/gcpy_environment_py312.yml
@@ -14,7 +14,7 @@ channels:
 dependencies:
   - cartopy        ==0.23.0     # Geospatial data processing
   - cf_xarray      ==0.9.1      # CF conventions for xarray
-  - dask           ==2024.5.2   # Parallel library; backend for xarray
+  - dask           ==2025.3.0   # Parallel library; backend for xarray
   - esmf           ==8.6.1      # Earth system modeling framework
   - esmpy          ==8.6.1      # Python wrapper for ESMF
   - gridspec       ==0.1.0      # Define Earth System Model grids

--- a/docs/environment_files/gcpy_environment_py313.yml
+++ b/docs/environment_files/gcpy_environment_py313.yml
@@ -22,7 +22,7 @@ channels:
 dependencies:
   - cartopy        ==0.24.0     # Geospatial data processing
   - cf_xarray      ==0.10.0     # CF conventions for xarray
-  - dask           ==2025.2.0   # Parallel library; backend for xarray
+  - dask           ==2025.3.0   # Parallel library; backend for xarray
   - esmf           ==8.8.0      # Earth System Model Framework
   - esmpy          ==8.8.0      # Python wrapper for ESMF
   - gridspec       ==0.1.0      # Define Earth System Model grids

--- a/docs/environment_files/read_the_docs_environment.yml
+++ b/docs/environment_files/read_the_docs_environment.yml
@@ -19,6 +19,6 @@ dependencies:
   - sphinx-autobuild==2021.3.14
   - recommonmark==0.7.1
   - docutils==0.20.1
-  - jinja2==3.1.5
+  - jinja2==3.1.6
 
 

--- a/docs/environment_files/read_the_docs_requirements.txt
+++ b/docs/environment_files/read_the_docs_requirements.txt
@@ -12,6 +12,6 @@ sphinxcontrib-bibtex==2.6.2
 sphinx-autobuild==2021.3.14
 recommonmark==0.7.1
 docutils==0.20.1
-jinja2==3.1.5
+jinja2==3.1.6
 
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires=[
         "cartopy==0.23.0",
         "cf_xarray==0.9.1",
-        "dask==2024.5.2",
+        "dask==2025.3.0",
         "esmf==8.6.1",
         "esmpy==8.6.1",
         "gridspec==0.1.0",


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST
 
### Describe the update
This PR updates the version numbers of dask and jinja2 to fix security issues.

- dask: 2024.5.2 -> 2025.3.0
- jinja2: 3.1.5 -> 3.1.6

### Expected changes
No changes are expected.

### Related Github Issue
- https://github.com/geoschem/gcpy/security/dependabot/24
- https://github.com/geoschem/gcpy/security/dependabot/25
- https://github.com/geoschem/gcpy/security/dependabot/26