### PR TITLE
Add example script to check GCHP emission diagnostics entries in HISTORY.rc and HEMCO_Diagn.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - TBD
 ### Added
-- Added `create_benchmark_sanity_check_table` routine to `gcpy/benchmark/benchmark_funcs.py` to test if variables are all zero
-or NaN
-- Added `check_gchp_emission_diags.py` example script (checks if entries in `HISTORY.rc` and `HEMCO_Diagn.rc` are consistent)
+- Added `create_benchmark_sanity_check_table` routine to `gcpy/benchmark/benchmark_funcs.py` to test if variables are all zero or NaN
+- Added `check_gchp_emission_diags.py` example script and documentation
 
 ## [1.6.1] - 2025-03-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated package version information in ReadTheDocs documentation
 - Bumped dask from version 2024.5.2 to 2025.3.0 to fix a security issue (raised by @dependabot)
 - Bumped jinja2 from version 3.1.5 to 3.1.6 to fix a security issue (raised by @dependabot)
-- Edited installation instructions via Mamba/Conda to more accurately reflect the needed commandsm
+- Edited installation instructions via Mamba/Conda to more accurately reflect the needed commands
 - Updated the ReadTheDocs "Releasing new versions" guide with info on conda-forge
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added `create_benchmark_sanity_check_table` routine to `gcpy/benchmark/benchmark_funcs.py` to test if variables are all zero
 or NaN
+- Added `check_gchp_emission_diags.py` example script (checks if entries in `HISTORY.rc` and `HEMCO_Diagn.rc` are consistent)
 
 ## [1.6.1] - 2025-03-24
 ### Added
@@ -24,7 +25,7 @@ or NaN
 - Updated package version information in ReadTheDocs documentation
 - Bumped dask from version 2024.5.2 to 2025.3.0 to fix a security issue (raised by @dependabot)
 - Bumped jinja2 from version 3.1.5 to 3.1.6 to fix a security issue (raised by @dependabot)
-- Edited installation instructions via Mamba/Conda to more accurately reflect the needed commands
+- Edited installation instructions via Mamba/Conda to more accurately reflect the needed commandsm
 - Updated the ReadTheDocs "Releasing new versions" guide with info on conda-forge
 
 ### Removed

--- a/docs/source/Check-GCHP-Emission-Diags.rst
+++ b/docs/source/Check-GCHP-Emission-Diags.rst
@@ -1,0 +1,112 @@
+.. _check-gchp:
+
+###############################
+Check GCHP emission diagnostics
+###############################
+
+Because `GCHP <https://gchp.readthedocs.io>`_ uses the MAPL library's
+History component for diagnostic archiving, all emission entries must
+be entered individually in both the `HISTORY.rc
+<https://gchp.readthedocs.io/en/stable/user-guide/config-files/HISTORY_rc.html>`_
+and `HEMCO_Diagn.rc
+<https://gchp.readthedocs.io/en/stable/geos-chem-shared-docs/doc/hemco-diagn.html>`_
+template files.  These template files are located in the
+:file:`run/GCHP` folder of the GEOS-Chem "science codebase"
+repository.
+
+This example demonstrates how you can cross-check the GCHP emission
+diagnostic entries.  This is especially important if you are adding
+new emissions diagnostics (so that you won't forget to update one file
+or the other).
+
+.. _check_gchp_code:
+
+===========
+Source code
+===========
+
+**Script location:** `gcpy/examples/diagnostics/check_gchp_emission_diags.py
+<https://github.com/geoschem/gcpy/blob/main/gcpy/examples/diagnostics/check_gchp_emission_diags.py>`_
+
+.. _check-gchp-usage:
+
+=====
+Usage
+=====
+
+First, clone the GCHP source code (if you haven't done so already).
+Then navigate to the :file:`run/GCHP` folder, which is the top-level
+folder for GCHP run directory template files.
+
+.. code-block:: console
+
+   $ git clone --recurse-submodules https://github.com/geoschem/GCHP
+
+   $ cd gchp/run
+
+Activate your GCPy environment with mamba or conda:
+
+.. code-block:: console
+
+   $ mamba activate gcpy_env    # If using mamba, or
+
+   $ conda activate gcpy_env    # If using conda
+
+Use one of these commands to check GCHP emissions diagnostics for a
+given simulation type:
+
+.. code-block:: console
+
+   $ python -m gcpy.examples.diagnostics.check_gchp_emission_diags . carbon
+
+   $ python -m gcpy.examples.diagnostics.check_gchp_emission_diags . fullchem
+
+   $ python -m gcpy.examples.diagnostics.check_gchp_emission_diags . TransportTracers
+
+   $ python -m gcpy.examples.diagnostics.check_gchp_emission_diags . tagO3
+
+You will then see output similar to this (fullchem example shown).
+
+.. code-block:: console
+
+   ===============================================================================
+   Common to both HISTORY.rc and HEMCO_Diagn.rc
+   ===============================================================================
+     #EmisCH4_Anthro
+     #EmisCH4_BioBurn
+     #EmisCH4_Ship
+     #EmisCH4_Total
+     #EmisSESQ_Biogenic
+     #InvAEIC_ACET
+     #InvAEIC_ALD2
+     #InvAEIC_ALK4
+     #InvAEIC_BCPI
+     #InvAEIC_C2H6
+     #InvAEIC_C3H8
+     ... etc ...
+     EmisACET_BioBurn
+     EmisACET_Biogenic
+     EmisACET_Ocean
+     EmisACET_Total
+     EmisACR_BioBurn
+     EmisACR_Total
+     EmisACTA_BioBurn
+     EmisACTA_Total
+     EmisALD2_Anthro
+     ... etc ...
+
+   ===============================================================================
+   In HISTORY.rc but not in HEMCO_Diagn.rc
+   ===============================================================================
+
+   ===============================================================================
+   In HEMCO_Diagn.rc but not in HISTORY.rc
+   ===============================================================================
+     #EmisNO_Fert
+     #InvCEDS_ALK6
+     #InvGTChlorine_HCl
+
+The output indicates that some diagnostics in :file:`HEMCO_Diagn.rc`
+are not present in :literal:`HISTORY.rc`, and should be added there
+for consistency.  A comment before the emission entry means that the
+diagnostic will be disabled by default.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,6 +56,7 @@ For documentation on setting up and running GEOS-Chem please see our
    Single-Panel
    Six-Panel
    Compare-Diags
+   Check-GCHP-Emission-Diags
    KPP-Standalone
 
 .. toctree::

--- a/gcpy/benchmark/modules/emission_species.yml
+++ b/gcpy/benchmark/modules/emission_species.yml
@@ -47,7 +47,7 @@ FullChemBenchmark:
   MTPA: Tg
   MTPO: Tg
   NH3: Tg
-  'NO': Tg
+  'NO': Tg  # Quotes are necessary, otherwise YAML interprets NO as False
   NO2: Tg
   O3: Tg
   OCPI: Tg

--- a/gcpy/examples/diagnostics/check_gchp_emission_diags.py
+++ b/gcpy/examples/diagnostics/check_gchp_emission_diags.py
@@ -115,11 +115,11 @@ def compare_containers(history_entries, hco_diagn_entries):
 
     # Diagnostic entries common to History and HEMCO
     result = {}
-    result["common"] = list(set_history & set_hemco)
+    result["common"] = sorted(list(set_history & set_hemco))
 
     # Diagnostic entries found in one file but not the other
-    result["in_history_not_hemco"] = list(set_history - set_hemco)
-    result["in_hemco_not_history"] = list(set_hemco - set_history)
+    result["in_history_not_hemco"] = sorted(list(set_history - set_hemco))
+    result["in_hemco_not_history"] = sorted(list(set_hemco - set_history))
 
     return result
 

--- a/gcpy/examples/diagnostics/check_gchp_emission_diags.py
+++ b/gcpy/examples/diagnostics/check_gchp_emission_diags.py
@@ -197,6 +197,6 @@ if __name__ == '__main__':
 
     if len(argv) != 3:
         MSG = "Usage: python -m gcpy.examples.diagnostics.check_gchp_emission_diags /path/to/run/GCHP SIMULATION-NAME"
-        raise ValueError(msg)
+        raise ValueError(MSG)
 
     main(argv[1], argv[2])

--- a/gcpy/examples/diagnostics/check_gchp_emission_diags.py
+++ b/gcpy/examples/diagnostics/check_gchp_emission_diags.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Compares GCHP emission diagnostic entries in HISTORY.rc
+and in HEMCO_Diagn.rc configuration files for consistency.
+"""
+from os.path import join, realpath
+from sys import argv
+from re import sub
+from gcpy.constants import ENCODING
+from gcpy.util import verify_variable_type
+
+
+def read_history(filename):
+    """
+    Reads the HISTORY_Diagn.rc file and returns a list of
+    diagnostic container names containing "Emis" or "Inv".
+
+    Args
+    filename : str  : Path to the HISTORY.rc file
+
+    Returns
+    result   : list : List of diagnostic entries
+    """
+    verify_variable_type(filename, str)
+
+    with open(filename, "r", encoding=ENCODING) as ifile:
+        result = []
+        for line in ifile:
+
+            # Only take lines with diagnostic fields
+            if "GCHPchem" not in line:
+                continue
+            if "Budget" in line:
+                continue
+            if "Emis" not in line and "Inv" not in line:
+                continue
+            if "Emissions.fields:" in line:
+                line = line.replace("Emissions.fields:", "")
+
+            # The diagnostic container is the 1st word
+            # (also strip quotes)
+
+            first_word = line.strip().split()[0]
+            first_word = first_word.replace("'", "").replace('"', "")
+
+            # Replace multiple # chars with a single # char
+            first_word = sub(r"#+", "#", first_word)
+
+            # Add to list of diagnosic entries
+            result.append(first_word)
+
+    return result
+
+
+def read_hemco_diagn(filename):
+    """
+    Reads the HEMCO_Diagn.rc file and returns a list of
+    diagnostic container names containing "Emis" or "Inv".
+
+    Args
+    filename : str  : Path to the HEMCO_Diagn.rc file
+
+    Returns
+    result   : list : List of diagnostic entries
+    """
+    verify_variable_type(filename, str)
+
+    with open(filename, "r", encoding=ENCODING) as ifile:
+        result = []
+        for line in ifile:
+
+            # Strip newlines and split into substrings
+            line = line.strip().split()
+
+            # Skip if the line is empty
+            if len(line) == 0:
+                continue
+
+            # Skip if the 1st word doesn't contain "Emis" or "Inv"
+            first_word = line[0]
+            if "Emis" not in first_word and "Inv" not in first_word:
+                continue
+
+            # Replace quotes 
+            first_word.replace("'", "").replace('"', "")
+
+            # Replace multiple "#" characters with a single "#"
+            first_word = sub(r"#+", "#", first_word)
+
+            # Append to list of diagnosic entries
+            result.append(first_word)
+
+    return result
+
+
+def compare_containers(history_entries, hco_diagn_entries):
+    """
+    Compares the list of GCHP emission entries in HISTORY.rc 
+    and HEMCO_Diagn.rc.  Returns the list of entries common to 
+    both, and in one file but not the other.
+
+    Args
+    history_containers   : list : Emission entries in HISTORY.rc
+    hco_diagn_containers : list : Emission entries in HEMCO_Diagn.rc
+
+    Returns
+    result               : dict : Results of the comparison
+    """
+    verify_variable_type(history_entries, list)
+    verify_variable_type(hco_diagn_entries, list)
+
+    # Convert lists to sets
+    set_history = set(history_entries)
+    set_hemco = set(hco_diagn_entries)
+
+    # Diagnostic entries common to History and HEMCO
+    result = {}
+    result["common"] = list(set_history & set_hemco)
+
+    # Diagnostic entries found in one file but not the other
+    result["in_history_not_hemco"] = list(set_history - set_hemco)
+    result["in_hemco_not_history"] = list(set_hemco - set_history)
+
+    return result
+
+
+def print_results(result):
+    """
+    Prints the results of the comparison between HISTORY.rc
+    and HEMCO_Diagn.rc
+
+    Args
+    result : dict : Dictionary with results of the comparison
+    """
+    verify_variable_type(result, dict)
+
+    print("="*79)
+    print("Common to both HISTORY.rc and HEMCO_Diagn.rc")
+    print("="*79)
+    for var in result["common"]:
+        print(f"  {var}")
+
+    print("")
+    print("="*79)
+    print("In HISTORY.rc but not in HEMCO_Diagn.rc")
+    print("="*79)
+    for var in result["in_history_not_hemco"]:
+         print(f"  {var}")
+
+    print("")
+    print("="*79)
+    print("In HEMCO_Diagn.rc but not in HISTORY.rc")
+    print("="*79)
+    for var in result["in_hemco_not_history"]:
+         print(f"  {var}")
+
+
+def main(path_to_rundir, simulation):
+    """
+    Main program.  Calls routines to read GCHP HISTORY.rc and
+    HEMCO_Diagn.rc files, to compare emission diagnostics, and
+    to print the results.
+
+    Args
+    path_to_rundir : str : Path to the run/GCHP folder
+    simulation     : str : Simulation name (e.g. fullchem)
+    """
+    verify_variable_type(path_to_rundir, str)
+    verify_variable_type(simulation, str)
+
+    # Create paths to HISTORY.rc and HEMCO_Diagn.rc
+    history_file = realpath(
+        join(
+            path_to_rundir,
+            "HISTORY.rc.templates",
+            f"HISTORY.rc.{simulation}"
+        )
+    )
+    hco_diagn_file = realpath(
+        join(
+            path_to_rundir,
+            "HEMCO_Diagn.rc.templates",
+            f"HEMCO_Diagn.rc.{simulation}"
+        )
+    )
+
+    # Read emission entries
+    history_entries = read_history(history_file)
+    hco_diag_entries = read_hemco_diagn(hco_diagn_file)
+
+    # Compare and print results
+    result = compare_containers(history_entries, hco_diag_entries)
+    print_results(result)
+
+
+if __name__ == '__main__':
+
+    if len(argv) != 3:
+        MSG = "Usage: python -m gcpy.examples.diagnostics.check_gchp_emission_diags /path/to/run/GCHP SIMULATION-NAME"
+        raise ValueError(msg)
+
+    main(argv[1], argv[2])


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
We have added an example script (plus documentation) to check the emission entries in the GCHP template files `run/GCHP/HEMCO_Diagn.rc.templates/HEMCO_Diagn.rc.{simulation}` and `run/GCHP/HISTORY.rc.templates/HISTORY.rc.{simulation}`.  This will make it less likely that diagnostic entries will be listed in one file but not in the other (as often happens when new diagnostics are added).

### Expected changes
```console
$ git clone --recurse-submodules https://github.com/geoschem/GCHP
$ cd gchp/run
$ mamba activate gcpy_env    # If using mamba, or
$ python -m gcpy.examples.diagnostics.check_gchp_emission_diags . fullchem
```
will give output such as:
```console
===============================================================================
Common to both HISTORY.rc and HEMCO_Diagn.rc
===============================================================================
  #EmisCH4_Anthro
  #EmisCH4_BioBurn
  #EmisCH4_Ship
  #EmisCH4_Total
  #EmisSESQ_Biogenic
  #InvAEIC_ACET
  #InvAEIC_ALD2
  #InvAEIC_ALK4
  #InvAEIC_BCPI
  #InvAEIC_C2H6
  #InvAEIC_C3H8
  ... etc ...
  EmisACET_BioBurn
  EmisACET_Biogenic
  EmisACET_Ocean
  EmisACET_Total
  EmisACR_BioBurn
  EmisACR_Total
  EmisACTA_BioBurn
  EmisACTA_Total
  EmisALD2_Anthro
  ... etc ...

===============================================================================
In HISTORY.rc but not in HEMCO_Diagn.rc
===============================================================================

===============================================================================
In HEMCO_Diagn.rc but not in HISTORY.rc
===============================================================================
  #EmisNO_Fert
  #InvCEDS_ALK6
  #InvGTChlorine_HCl
```
The output indicates that some diagnostics in `HEMCO_Diagn.rc` are not present in `HISTORY.rc`, and should be added there
for consistency.  A comment before the emission entry means that the diagnostic will be disabled by default.