### PR TITLE
Now use esmf/esmpy 8.8.1 in the GCPy environment based on Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - TBD
 ### Added
-- Added code profiling scripts (in `gcpy/gcpy/profile`) to read and display output from gprofng and Intel VTune profilers
-- Added a chapter on using code profiling tools in the ReadTheDocs documentation
+- Added `create_benchmark_sanity_check_table` routine to `gcpy/benchmark/benchmark_funcs.py` to test if variables are all zero or NaN
 
 ### Changed
 - Updated `gcpy_environment_py313.yml` to use `esmf==8.8.1` and `esmpy==8.8.1` to fix package inconsistency issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - TBD
 ### Added
-- Added `create_benchmark_sanity_check_table` routine to `gcpy/benchmark/benchmark_funcs.py` to test if variables are all zero
-or NaN
+- Added code profiling scripts (in `gcpy/gcpy/profile`) to read and display output from gprofng and Intel VTune profilers
+- Added a chapter on using code profiling tools in the ReadTheDocs documentation
+
+### Changed
+- Updated `gcpy_environment_py313.yml` to use `esmf==8.8.1` and `esmpy==8.8.1` to fix package inconsistency issues
 
 ## [1.6.1] - 2025-03-24
 ### Added

--- a/docs/environment_files/gcpy_environment_py313.yml
+++ b/docs/environment_files/gcpy_environment_py313.yml
@@ -23,8 +23,8 @@ dependencies:
   - cartopy        ==0.24.0     # Geospatial data processing
   - cf_xarray      ==0.10.0     # CF conventions for xarray
   - dask           ==2025.3.0   # Parallel library; backend for xarray
-  - esmf           ==8.8.0      # Earth System Model Framework
-  - esmpy          ==8.8.0      # Python wrapper for ESMF
+  - esmf           ==8.8.1      # Earth System Model Framework
+  - esmpy          ==8.8.1      # Python wrapper for ESMF
   - gridspec       ==0.1.0      # Define Earth System Model grids
   - ipython        ==9.0.0      # Interactive Python (used by Jupyter)
   - joblib         ==1.4.2      # Parallelize python code

--- a/docs/source/Getting-Started-with-GCPy.rst
+++ b/docs/source/Getting-Started-with-GCPy.rst
@@ -54,10 +54,10 @@ GCPy requires several other Python packages, which are listed below.
      - 2025.3.0
    * - esmf [#A]_
      - 8.6.1
-     - 8.8.0
+     - 8.8.1
    * - `esmpy <https://www.earthsystemcog.org/projects/esmpy/>`_ [#A]_
      - 8.6.1
-     - 8.8.0
+     - 8.8.1
    * - gridspec
      - 0.1.0
      - 0.1.0


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR updates the esmf and esmpy versions from 8.8.0 to 8.8.1 in the `docs/source/gcpy_environment_py313.yml` environment specification file.  

A bug had caused esmf 8.8.0 and esmpy 8.8.0.b0 (beta version 0) to be published to conda-forge.  When building the GCPy environment this resulted in several `VersionWarning` messages after each command was typed, such as:

```console
$ python -m gcpy.examples.plotting.create_test_plot
/home/bob/mambaforge/envs/dask_13_env/lib/python3.13/site-packages/esmpy/interface/loadESMF.py:94: VersionWarning: ESMF installation version 8.8.0, ESMPy version 8.8.0b0
  warnings.warn("ESMF installation version {}, ESMPy version {}".format(
```

### Expected changes
Updating the esmf/esmpy versions to 8.8.1 will prevent the `VersionWarning` messages from being generated.

### Related Github Issue
- https://github.com/esmf-org/esmf/issues/367