### PR TITLE
Fix logic for orbit direction time offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased] - TBD
+### Fixed
+- Fix the logic of ravel_1D that creates orbit file for 1D GCHP diagnostic
 
 ## [1.6.1] - 2025-03-24
 ### Added

--- a/gcpy/raveller_1D.py
+++ b/gcpy/raveller_1D.py
@@ -40,8 +40,8 @@ def create_track_func(args):
     #(ds['latitude'] / 180) * args.vertical_scan_time) % 24
     # vary overpass time with latitude
     overpass_offset = ds['latitude'] / 90 * 24 / args.orbits_per_day / 4 * 60
-    if args.direction == 'ascending':
-        # overpass delayed at high northern latitudes if ascending
+    if args.direction == 'descending':
+        # overpass advanced at high northern latitudes if descending
         overpass_offset = -overpass_offset
 
     longitude = ds.longitude.values

--- a/gcpy/raveller_1D.py
+++ b/gcpy/raveller_1D.py
@@ -57,7 +57,7 @@ def create_track_func(args):
     ds = ds.sortby('time')
 
     ds = ds.reset_index('track')
-    ds = ds.assign_coords({'track': ds.time}).drop(
+    ds = ds.assign_coords({'track': ds.time}).drop_vars(
         'time').rename({'track': 'time'})
 
     ds['longitude'].attrs['long_name'] = 'longitude'
@@ -67,7 +67,7 @@ def create_track_func(args):
     ds['latitude'].attrs['long_name'] = 'latitude'
     ds['latitude'].attrs['units'] = 'degrees_north'
 
-    ds2 = ds.drop(['nf', 'Ydim', 'Xdim'])
+    ds2 = ds.drop_vars(['nf', 'Ydim', 'Xdim'])
     ds2['nf'] = xr.DataArray(ds.nf.values, dims=['time'])
     ds2['Ydim'] = xr.DataArray(ds.Ydim.values, dims=['time'])
     ds2['Xdim'] = xr.DataArray(ds.Xdim.values, dims=['time'])
@@ -126,7 +126,7 @@ def unravel_func(args):
 
     # Create a multiindex for nf,Ydim,Xdim
     track_mi = pd.MultiIndex.from_arrays([track.nf.values, track.Ydim.values, track.Xdim.values], names=['nf', 'Ydim', 'Xdim'])
-    track = track.drop(['nf', 'Ydim', 'Xdim', 'latitude', 'longitude'])
+    track = track.drop_vars(['nf', 'Ydim', 'Xdim', 'latitude', 'longitude'])
 
     # Merge datasets
     tracked_output = tracked_output


### PR DESCRIPTION
### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Describe the update

Fix the logic of ravel_1D program that creates orbit file for 1D GCHP diagnostic

Overpassing time advanced (negative offset) at northern latitudes and delayed (positive offset) at southern latitudes if descending. So time offset needs to be inversed for descending but not ascending.