### PR TITLE
Add "method" keyword argument to make_regridder_* routines in gcpy/regrid.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ n
 - Added new benchmark functions `make_benchmark_collection_2d_var_plots` and `make_benchmark_collection_3d_var_plots` which can be used with any GEOS-Chem output collection
 - Added 1-month benchmark comparison plot options for `Budget`, `UVFlux`, and `StateMet` collections (2D and 3D vars separately) which are off by default
 - Added `export MPLBACKEND=agg` to `gcpy/benchmark/modules/benchmark_slurm.sh` to request a non-interactive MatPlotLib backend
+- Added `method` keyword argument to `make_regridder_*` routines in `regrid.py`, with default value `conservative`
 
 ### Changed
 - Updated `gcpy_environment_py313.yml` to use `esmf==8.8.1` and `esmpy==8.8.1` to fix package inconsistency issues

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -105,10 +105,10 @@ def file_regrid(
     #  -- Bob Yantosca & Lizzie Lundgren (24 Oct 2023)
     if not np.array_equal(sg_params_in, [1.0, 170.0, -90.0]) or \
        not np.array_equal(sg_params_out, [1.0, 170.0, -90.0]):
-       msg = "Regridding to or from cubed-sphere stretched grids is\n" + \
-           "currently not supported.  Please use the offline regridding\n" + \
-           "method described in the Regridding section of gcpy.readthedocs.io."
-       raise RuntimeError(msg)
+        msg = "Regridding to or from cubed-sphere stretched grids is\n" + \
+            "currently not supported.  Please use the offline regridding\n" + \
+            "method described in the Regridding section of gcpy.readthedocs.io."
+        raise RuntimeError(msg)
     # ------------------------------------------------------------------
 
     # Load dataset
@@ -330,7 +330,7 @@ def regrid_cssg_to_cssg(
     """
     if verbose:
         print("file_regrid.py: Regridding from CS/SG to CS/SG")
-        
+
     # Keep all xarray attributes
     with xr.set_options(keep_attrs=True):
 
@@ -1128,7 +1128,7 @@ def rename_restart_variables(
         # checkpoint -> classic/diagnostic
         # ==============================================================
         for var in dset.data_vars.keys():
-            if var == "DELP_DRY" or var == "DELPDRY":
+            if var in ("DELP_DRY", "DELPDRY"):
                 old_to_new[var] = "Met_DELPDRY"
             if var == "BXHEIGHT":
                 old_to_new[var] = "Met_BXHEIGHT"

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -18,7 +18,8 @@ def make_regridder_L2L(
         weightsdir='.',
         reuse_weights=False,
         in_extent=[-180, 180, -90, 90],
-        out_extent=[-180, 180, -90, 90]
+        out_extent=[-180, 180, -90, 90],
+        method="conservative",
 ):
     """
     Create an xESMF regridder between two lat/lon grids
@@ -78,14 +79,14 @@ def make_regridder_L2L(
         regridder = xe.Regridder(
             llgrid_in,
             llgrid_out,
-            method='conservative',
+            method=method,
             filename=weightsfile,
             reuse_weights=reuse_weights)
     except BaseException:
         regridder = xe.Regridder(
             llgrid_in,
             llgrid_out,
-            method='conservative',
+            method=method,
             filename=weightsfile,
             reuse_weights=reuse_weights)
     return regridder
@@ -96,7 +97,8 @@ def make_regridder_C2L(
         llres_out,
         weightsdir='.',
         reuse_weights=True,
-        sg_params=[1, 170, -90]
+        sg_params=[1, 170, -90],
+        method="conservative",
 ):
     """
     Create an xESMF regridder from a cubed-sphere to lat/lon grid
@@ -151,14 +153,14 @@ def make_regridder_C2L(
             regridder = xe.Regridder(
                 csgrid_list[i],
                 llgrid,
-                method='conservative',
+                method=method,
                 filename=weightsfile,
                 reuse_weights=reuse_weights)
         except BaseException:
             regridder = xe.Regridder(
                 csgrid_list[i],
                 llgrid,
-                method='conservative',
+                method=method,
                 filename=weightsfile,
                 reuse_weights=reuse_weights)
         regridder_list.append(regridder)
@@ -175,7 +177,9 @@ def make_regridder_S2S(
         tlon_out=170,
         tlat_out=-90,
         weightsdir='.',
-        verbose=True):
+        verbose=True,
+        method="conservative",
+):
     """
     Create an xESMF regridder from a cubed-sphere / stretched-grid grid
     to another cubed-sphere / stretched-grid grid.
@@ -238,7 +242,7 @@ def make_regridder_S2S(
             try:
                 regridder = xe.Regridder(igrid_list[i_face],
                                          ogrid_list[o_face],
-                                         method='conservative',
+                                         method=method,
                                          filename=weightsfile,
                                          reuse_weights=reuse_weights)
                 regridder_list[-1][i_face] = regridder
@@ -254,7 +258,8 @@ def make_regridder_L2S(
         csres_out,
         weightsdir='.',
         reuse_weights=True,
-        sg_params=[1, 170, -90]
+        sg_params=[1, 170, -90],
+        method="conservative"
 ):
     """
     Create an xESMF regridder from a lat/lon to a cubed-sphere grid
@@ -309,14 +314,14 @@ def make_regridder_L2S(
             regridder = xe.Regridder(
                 llgrid,
                 csgrid_list[i],
-                method='conservative',
+                method=method,
                 filename=weightsfile,
                 reuse_weights=reuse_weights)
         except BaseException:
             regridder = xe.Regridder(
                 llgrid,
                 csgrid_list[i],
-                method='conservative',
+                method=method,
                 filename=weightsfile,
                 reuse_weights=reuse_weights)
         regridder_list.append(regridder)
@@ -643,7 +648,7 @@ def regrid_comparison_data(
                 new_data=new_data[cmpminlat_ind:cmpmaxlat_ind +
                                   1, cmpminlon_ind:cmpmaxlon_ind + 1].squeeze()
             return new_data
-        elif cmpgridtype == "ll":
+        if cmpgridtype == "ll":
             # CS to ll
             if nlev == 1:
                 new_data = np.zeros([global_cmp_grid['lat'].size,
@@ -662,7 +667,7 @@ def regrid_comparison_data(
                 new_data=new_data[cmpminlat_ind:cmpmaxlat_ind +
                                   1, cmpminlon_ind:cmpmaxlon_ind + 1].squeeze()
             return new_data
-        elif cmpgridtype == "cs":
+        if cmpgridtype == "cs":
             # CS to CS
             # Reformat dimensions to T, Z, F, Y, X
             if 'Xdim' in data.dims:
@@ -803,7 +808,7 @@ def reformat_dims(
 
     # %%%% Renaming from the common format %%%%
     # Reverse rename
-    ds = rename_existing(ds, 
+    ds = rename_existing(ds,
         {v: k for k, v in dim_formats[format].get('rename', {}).items()})
 
     # Ravel dimensions


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This is the companion PR to #361 by @nicodgomez.  We have now added the `method` keyword argument (with default value `conservative`) to the following routines in `gcpy/regrid.py`:
- `make_regridder_L2L`
- `make_regridder_C2L`
- `make_regridder_S2S`
- `make_regridder_L2S`

This will allow the value of `method` passed to these routines to be in turn passed to the `xesmf.Regridder` function.

Also, some minor fixes suggested by the Pylint linter were applied to `gcpy/file_regrid.py` and `gcpy/regrid.py`.

### Expected changes
Using `file_regrid.py` such to regrid lat-lon files to a different lat-lon grid, such as:
```console
$ python -m gcpy.file_regrid                                 \
  --filein         GEOSChem.Restart.20190101_0000z.nc4     \
  --dim_format_in  classic                                 \
  --fileout        GEOSChem.Restart.20190101_0000z_2x25.nc \
  --ll_res_out     2x2.5                                   \
  --dim_format_out classic
```
will no longer result in the `TypeError` described by @nicodgomez in #361.

### Related Github Issue

- Closes #361
