### PR TITLE
Update the "end of search" criteria in benchmark_scrape_classic_timers.py to avoid being spoofed by output from Intel VTune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Modified criteria for terminating read of log files in `benchmark_scrape_gcclassic_timers.py` to avoid being spoofed by  output that is attached by Intel VTune
+
 ## [1.6.2] - 2025-06-12
 ### Added
 - Added `create_benchmark_sanity_check_table` routine to `gcpy/benchmark/benchmark_funcs.py` to test if variables are all zero or NaN

--- a/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
+++ b/gcpy/benchmark/modules/benchmark_scrape_gcclassic_timers.py
@@ -113,7 +113,7 @@ def read_one_text_file(text_file):
             # Set a flag to denote the start & end of timing info
             if "Unit conversions" in line:
                 keep_line = True
-            if "----------" in line:
+            if "-"*78 in line:
                 keep_line = False
                 break
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
In `gcpy/benchmark/modules/benchmark_scrape_gcclassic.timers.py`, the code starts reading the timers information backwards from the end of the file.  The signal to stop reading was if a line contained `----------`.  However, when output from the Intel VTune profiler is appended to the end of a GEOS-Chem Classic log file, there is a line with at least many `-` characters, which causes the parsing of the file to end before the timing information is reached.

The solution is to change the criteria to look for a line with 78 `-` characters in a row (which occurs just before `GEOS-Chem` timer row.  This will allow the parsing of the log file to proceed normally.

NOTE: This is not an issue when `benchmark_scrape_gcclassic_timers.py` reads the `gcclassic_timers.json` file.

### Expected changes
This will allow `benchmark_scrape_gcclassic_timers.py` to be able to read the GEOS-Chem timing information from log files where Intel VTune has appended a report to the end of the file.