### PR TITLE
Rewrite algorithm to save PDF output to avoid using PdfMerger; Use PdfReader and PdfWriter instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modified criteria for terminating read of log files in `benchmark_scrape_gcclassic_timers.py` to avoid being spoofed by  output that is attached by Intel VTune
 - Moved `gprofng_text_to_data_units` to function `text_to_data_units` in `gcpy/plot/core.py` so that it can be used by `gprofng_functions` and `vtune_plot_hotspots`
 - Updated GitHub badges in `README.md` and `docs/source/index.rst`
-- Expanded possible stretched grid attribute names to include STRETCH_FACTOR, TARGET_LAT, and TARGET_LON
+- Expanded possible stretched grid attribute names to include `STRETCH_FACTOR`, `TARGET_LAT`, and `TARGET_LON`
 - Changed regridding for plots to always compare stretched-grid to uniform CS grid on the uniform CS grid rather than whatever grid is ref
+- Updated PDF writing algorithm in `compare_single_level` and `compare_zonal_mean` to use `PdfReader` and `PdfWriter` instead of `PdfMerger`
 
 ### Fixed
 - Fixed grid area calculation scripts of `grid_area` in `gcpy/gcpy/cstools.py`
 - Fixed various security issues in GitHub Actions workflows
 - Fixed colorbar bounds for case of comparing cubed-sphere grids
+
+### Removed
+- Removed `PdfMerger()` from `compare_single_level` and `compare_zonal_mean`, it has been removed in pypdf >= 5.0.0
 
 ## [1.6.2] - 2025-06-12
 ### Added


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This is the companion PR to issue #372.  We have removed references to the obsolete `PdfMerger()` class from `gcpy/plot/compare_single_level.py` and `gcpy/plot/compare_zonal_mean.py`.  Instead, we now use `PdfWriter()` and `PdfReader()`.   

`PdfMerger()` was removed from pypdf 5.0.0 and later versions.   

### Expected changes
Using `compare_single_level.py` or `compare_zonal_mean.py` will no longer trigger the following error:
```console
pypdf.errors.DeprecationError: PdfMerger is deprecated and was removed in pypdf 5.0.0. Use PdfWriter instead.
```
if your Python environment contains pypdf 5.0.0 or later.

### Related Github Issue
- Closes #372