### PR TITLE
Update pypdf to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved `gprofng_text_to_data_units` to function `text_to_data_units` in `gcpy/plot/core.py` so that it can be used by `gprofng_functions` and `vtune_plot_hotspots`
 - Updated GitHub badges in `README.md` and `docs/source/index.rst`
 - Expanded possible stretched grid attribute names to include STRETCH_FACTOR, TARGET_LAT, and TARGET_LON
-- Changed regridding for plots to always compare stretched-grid to uniform CS grid on the uniform CS grid rather than whatever grid is ref
+- Changed regridding for plots to always compare stretched-grid to
+uniform CS grid on the uniform CS grid rather than whatever grid is ref
+- Bumped `pypdf` from version 4.2.0 to 6.0.0 in `docs/environments/gcpy_environment_py312.yml`
+- Bumped `pypdf` from version 5.3.1 to 6.0.0 in `docs/environments/gcpy_environment_py313.yml`
 
 ### Fixed
 - Fixed grid area calculation scripts of `grid_area` in `gcpy/gcpy/cstools.py`

--- a/docs/environment_files/gcpy_environment_py312.yml
+++ b/docs/environment_files/gcpy_environment_py312.yml
@@ -30,7 +30,7 @@ dependencies:
   - pylint         ==3.2.2      # Python linter
   - pyproj         ==3.6.1      # Python map projections library
   - python         ==3.12.0     # Python language
-  - pypdf          ==4.2.0      # PDF utilities (bookmarks, etc.)
+  - pypdf          ==6.0.0      # PDF utilities (bookmarks, etc.)
   - requests       ==2.32.4     # HTTP library
   - scipy          ==1.13.1     # Scientific python package
   - sparselt       ==0.1.3      # Regridding earth system model data

--- a/docs/environment_files/gcpy_environment_py313.yml
+++ b/docs/environment_files/gcpy_environment_py313.yml
@@ -30,7 +30,7 @@ dependencies:
   - pylint         ==3.3.4      # Python linter
   - pyproj         ==3.7.1      # Python map projections library
   - python         ==3.13       # Python language
-  - pypdf          ==5.3.1      # PDF utilities (bookmarks, etc.)
+  - pypdf          ==6.0.0      # PDF utilities (bookmarks, etc.)
   - requests       ==2.32.4     # HTTP library
   - scipy          ==1.15.2     # Scientific python package
   - sparselt       ==0.1.3      # Regridding earth system model data


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

This PR bumps the pypdf package version to 6.0.0. as suggested by Dependabot.  Environment files have been updated accordingly.

### Expected changes
No changes are expected

### Related Github Issue

- See PR #375 