### PR TITLE
Fixes for offline regridding and stretched grid plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `gcpy/profile/vtune_plot_hotspots.py` to plot a bargraph of hotspots from Intel VTune reports
 - Added ReadTheDocs documentation for plotting hotspots from Intel VTune reports
 - Added "Lint" GitHub Action to check other actions for security issues
-- Added `gcpy_environment_py314.ym1` to specify the GCPy environment packages with Python 3.14 
+- Added `gcpy_environment_py314.ym1` to specify the GCPy environment packages with Python 3.14
 - Added GitHub action `build-gcpy-environment-py314.yml` to test building the GCPy environment with Python 3.14
-- Added call to drop GC-Classic variables when regridding a GC-Classic restart file to cubed-sphere 
+- Added call to drop GC-Classic variables when regridding a GC-Classic restart file to cubed-sphere
 - Added `Ap` and `Bp` parameters for GCAP2 vertical grids
 - Added `GCAP2_102L_grid`, `GCAP2_74L_grid`, and `GCAP2_40L_grid` to `grid.py`
 
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bumped `pypdf` from version 5.3.1 to 6.0.0 in `docs/environments/gcpy_environment_py313.yml`
 - Moved `Ap` and `Bp` parameters that define vertical grids from `grid.py` to `vgrid_defs.py`
 - Bumped `pip` to version 25.2 as suggested by Dependabot
+- Required passing template output file to offline restart regridding that has grid dimensions that do not match target restart grid
+- Changed offline restart regridding to preserve source restart file precision
 
 ### Fixed
 - Fixed grid area calculation scripts of `grid_area` in `gcpy/gcpy/cstools.py`

--- a/gcpy/plot/compare_single_level.py
+++ b/gcpy/plot/compare_single_level.py
@@ -247,8 +247,8 @@ def compare_single_level(
     if 'stretch_factor' in refdata.attrs:
         sg_ref_params = [
             refdata.attrs['stretch_factor'],
-            refdata.attrs['target_lon'],
-            refdata.attrs['target_lat']]
+            refdata.attrs['target_longitude'],
+            refdata.attrs['target_latitude']]
     elif 'STRETCH_FACTOR' in refdata.attrs:
         sg_ref_params = [
             refdata.attrs['STRETCH_FACTOR'],
@@ -261,8 +261,8 @@ def compare_single_level(
     if 'stretch_factor' in devdata.attrs:
         sg_dev_params = [
             devdata.attrs['stretch_factor'],
-            devdata.attrs['target_lon'],
-            devdata.attrs['target_lat']]
+            devdata.attrs['target_longitude'],
+            devdata.attrs['target_latitude']]
     elif 'STRETCH_FACTOR' in devdata.attrs:
         sg_dev_params = [
             devdata.attrs['STRETCH_FACTOR'],

--- a/gcpy/plot/compare_zonal_mean.py
+++ b/gcpy/plot/compare_zonal_mean.py
@@ -310,8 +310,8 @@ def compare_zonal_mean(
     if 'stretch_factor' in refdata.attrs:
         sg_ref_params = [
             refdata.attrs['stretch_factor'],
-            refdata.attrs['target_lon'],
-            refdata.attrs['target_lat']]
+            refdata.attrs['target_longitude'],
+            refdata.attrs['target_latitude']]
     elif 'STRETCH_FACTOR' in refdata.attrs:
         sg_ref_params = [
             refdata.attrs['STRETCH_FACTOR'],
@@ -324,8 +324,8 @@ def compare_zonal_mean(
     if 'stretch_factor' in devdata.attrs:
         sg_dev_params = [
             devdata.attrs['stretch_factor'],
-            devdata.attrs['target_lon'],
-            devdata.attrs['target_lat']]
+            devdata.attrs['target_longitude'],
+            devdata.attrs['target_latitude']]
     elif 'STRETCH_FACTOR' in devdata.attrs:
         sg_dev_params = [
             devdata.attrs['STRETCH_FACTOR'],

--- a/gcpy/regrid_restart_file.py
+++ b/gcpy/regrid_restart_file.py
@@ -377,6 +377,13 @@ def regrid(dataset, output_template, weights_file):
         np.prod(output_template_shape) != weights.dst_grid_dims.item()
     )
     if resize_output_template:
+        error_message = (
+            "GCHP output template grid resolution must be the same size "
+            "as the target grid! For example, if creating restart file "
+            " with parameters c24 and stretch factor 10, the template "
+            " GCHP file must be c24 with any or no stretch factor."
+        )
+        raise ValueError(error_message)
         if is_gchp_restart_file(output_template):
             # This is useful for stretched-grid simulations because they usually
             # don't have a "normal" grid size

--- a/gcpy/regrid_restart_file.py
+++ b/gcpy/regrid_restart_file.py
@@ -528,7 +528,6 @@ def regrid_restart_file(
 
     dataset, output_template = drop_variables(dataset, output_template)
     dataset = regrid(dataset, output_template, weights_file=regrid_weights)
-    dataset = update_encoding(dataset)
     check_for_nans(dataset)
 
     if stretch_factor and target_lat and target_lon:


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This update applies the following changes to offline regridding code in function `regrid_restart_file`. That function is currently used to create GCHP stretched grid restart files via offline regridding.
1. It removes the call to `update_encoding` which previously converted all restart variables to floating point precision. Precisions of the source restart file should instead be preserved, e.g. double precision for species concentrations.
2. It prevents passing an output template file that has different dimension sizes than the target restart file. There is existing code that can resize the template restart file dataset but it currently causes a corrupt output restart file. That code is kept in case future work is done on it, but new error handling now causes exit with an error if it is triggered.

This PR also fixes the names of stretched grid target latitude and longitude attributes used in plotting code. This bug crept in during recent development and is not part of an existing release. It is therefore not mentioned in the changelog.

### Expected changes

This update fixes plotting of stretched grid restart variables and makes GCHP restarts regridding using offline regridding better match restart generated using online regridding (GCPy function `regrid_file`). Note that the restarts for these two methods do not exactly match. That is currently under investigation.

### Reference(s)

None

### Related Github Issue

None
