### PR TITLE
Fix error when using a template at different resolution to regrid a restart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to GCPy will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased] - TBD
+### Fixed
+- Allow using a template at different grid resolutions in `gcpy/regrid_restart_file.py`
+
 ## [1.7.1] - 2026-02-03
 ### Changed
 - Bumped `pip` to version 26.0 in `setup.py` and environment files


### PR DESCRIPTION
### Name and Institution (Required)

Name: Dandan Zhang
Institution: Harvard University

### Describe the update

I need to regrid restart file to a resolution that may not be available at the resolution of current generated restarts files.
As the template for a restarting file is only to add attributes, it should be benign to use templates at different resolutions.
Thus, 
- I removed the part of raising error when the template resolution does not match. Instead, I cleaned global attributes from the template and only add attributes when stretched GCHP is used.
- I also update the `drop` to be `drop_vars` as `drop` is deprecated in newer `xarray` version.

### Expected changes

It will allow regridding restart file to any spatial resolution regardless the resolution of the template restart file.

### Reference(s)

N/A
