### PR TITLE
Implement fix in gcpy/regrid.py for numpy backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Allow using a template at different grid resolutions in `gcpy/regrid_restart_file.py`
+- Implemented a workaround in `gcpy/regrid.py` to allow use of either `np.product` or `np.prod` depending on the Numpy version
 
 ## [1.7.1] - 2026-02-03
 ### Changed

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -1094,7 +1094,14 @@ def regrid_vertical(src_data_3d, xmat_regrid, target_levs=None):
 
     nlev_out = xmat_renorm.shape[1]
     out_shape = [nlev_out] + list(src_data_3d.shape[1:])
-    n_other = np.product(src_data_3d.shape[1:])
+    # ------------------------------------------------------------------
+    # The np.product function was changed to np.prod in version 2.0,
+    # so implement this workaround for backward compatibility.
+    try:
+        np_other = np.prod(src_data_3d.shape[1:])      # NumPy >= 2.0
+    except AttributeError:
+        np_other = np.product(src_data_3d.shape[1:])   # NumPy < 2.0
+    # ------------------------------------------------------------------
     temp_data = np.zeros((nlev_out, n_other))
     in_data = np.reshape(np.array(src_data_3d), (nlev_in, n_other))
     for ix in range(n_other):


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
Routine `regrid_vertical` in `gcpy/regrid.py` uses the `numpy.product` function.  However, this function was renamed to `numpy.prod` in Numpy version 2.0.

We have added a try/except block to first try to call `np.prod`, and then if that fails, to try `np.product`.  This is the most pythonic approach.

NOTE: This error only happens when trying to plot data on different vertical grids (which is why we haven't seen this until recently).

### Expected changes
This will allow vertical regridding to proceed regardless of Numpy version.

### Related Github Issue

- See #82