### PR TITLE
Update GitHub Actions to the latest versions to avoid Node20.js deprecation warnings

### DIFF
--- a/.github/workflows/build-gcpy-environment-py312.yml
+++ b/.github/workflows/build-gcpy-environment-py312.yml
@@ -1,7 +1,6 @@
 ---
 #
-# GitHub action to build the GCPy production environment
-# (for Python 3.12) with micromamba
+# GitHub action to build the GCPy production environment (Python 3.12)
 # See: https://github.com/marketplace/actions/setup-micromamba
 #
 name: build-gcpy-environment-py312
@@ -10,24 +9,26 @@ on:
   push:
     branches: [ "main", "dev", "dependabot/*" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main", "dev" ]
+    # These must be a subset of the branches above
+    branches: [ "main", "dev", "dependabot/*" ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
     steps:
       - name: Checkout the GCPy repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Create "gcpy_env" environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: 'latest'
           environment-file: docs/environment_files/gcpy_environment_py312.yml

--- a/.github/workflows/build-gcpy-environment-py313.yml
+++ b/.github/workflows/build-gcpy-environment-py313.yml
@@ -1,7 +1,6 @@
 ---
 #
-# GitHub action to build the GCPy production environment
-# (for Python 3.13) with micromamba
+# GitHub action to build the GCPy production environment (Python 3.13)
 # See: https://github.com/marketplace/actions/setup-micromamba
 #
 name: build-gcpy-environment-py313
@@ -10,24 +9,26 @@ on:
   push:
     branches: [ "main", "dev", "dependabot/*" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main", "dev" ]
+    # These must be a subset of the branches above
+    branches: [ "main", "dev", "dependabot/*" ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
     steps:
       - name: Checkout the GCPy repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Create "gcpy_env" environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: 'latest'
           environment-file: docs/environment_files/gcpy_environment_py313.yml
@@ -38,8 +39,4 @@ jobs:
 
       - name: Test if "import gcpy" works
         run: python -c "import gcpy"
-        shell: micromamba-shell {0}
-
-      - name: Test if we can create a plot
-        run: python -m gcpy.examples.plotting.create_test_plot
         shell: micromamba-shell {0}

--- a/.github/workflows/build-rtd-environment.yml
+++ b/.github/workflows/build-rtd-environment.yml
@@ -1,6 +1,6 @@
 ---
 #
-# GitHub action to build the ReadTheDocs environment with micromamba
+# GitHub action to build the ReadTheDocs environment
 # See: https://github.com/marketplace/actions/setup-micromamba
 #
 name: build-rtd-environment
@@ -9,24 +9,26 @@ on:
   push:
     branches: [ "main", "dev", "dependabot/*" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main", "dev" ]
+    # These must be a subset of the branches above
+    branches: [ "main", "dev", "dependabot/*" ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
     steps:
       - name: Checkout the GCPy repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Create "rtd_env" environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: 'latest'
           environment-file: docs/environment_files/read_the_docs_environment.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,14 +46,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -67,7 +67,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -80,6 +80,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/lint-ci-workflows.yml
+++ b/.github/workflows/lint-ci-workflows.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Checkout code
         with:
           persist-credentials: false
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Installs Python 3.x
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
 
       - name: Checkout GCPy code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -49,3 +49,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+          attestations: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-label: 'stale'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bumped `pypdf` to version 6.7.1 in `setup.py` and environment files
 - Updated `benchmark/modules/emission_species.yml` to be consistent w/ the FullChemBenchmark emission diagnostics in GC 14.7.0 and later
 - Bumped `requests` to version 2.33.0 (suggested by @dependabot)
+- Updated GitHub Actions to the latest versions
 
 ### Fixed
 - Allow using a template at different grid resolutions in `gcpy/regrid_restart_file.py`
 - Implemented a workaround in `gcpy/regrid.py` to allow use of either `np.product` or `np.prod` depending on the Numpy version
+
+### Removed
+- Removed Python 3.9 from the GitHub Actions that try to build a Python environment; This version is now de-supported
 
 ## [1.7.1] - 2026-02-03
 ### Changed


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

GitHub Actions is retiring Node20.js from all of its runners in June 2026:

>gnu (Debug)Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Therefore we have updated all of the GitHub Actions workflow files to check out the latest version of each action.

| Old version | New version |
| ----- | ---- |
| actions/checkout@v4 | actions/checkout@v6 |
| actions/setup-micromamba@v2 | actions/setup-micromamba@v3 |
| actions/setup-python@v5 | actions/setup-python@v6 |
| actions/stale@v5 | actions/stale@v10 |

We have also removed Python 3.9 from GitHub actions that test building python environments and have also added Python 3.14.

### Expected changes
- This is a no-diff-to-benchmark update that will only affect GitHub actions.
- This will allow our GitHub Actions to proceed as normal after GitHub removes Node20.js support in June.
- This will make our setup more future-proof against further GitHub Actions system changes.
