### PR TITLE
Add updates for emission species and inventories used in fullchem benchmark simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to GCPy will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Added
+- Added HONO and NAP to `gcpy/benchmark/modules/emission_species.yml`
+
 ### Changed
 - Bumped `pypdf` to version 6.7.1 in `setup.py` and environment files
 - Updated `benchmark/modules/emission_species.yml` to be consistent w/ the FullChemBenchmark emission diagnostics in GC 14.7.0 and later
@@ -18,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 - Removed Python 3.9 from the GitHub Actions that try to build a Python environment; This version is now de-supported
+- Removed emission inventories no longer used in benchmark simulations from `gcpy/benchmark/modules/emission_inventories.yml`
+- Removed the hotfix to skip `InvAFCID` emission diagnostics in routine `create_total_emissions_table`
 
 ## [1.7.1] - 2026-02-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] - TBD
 ### Added
 - Added HONO and NAP to `gcpy/benchmark/modules/emission_species.yml`
+- Added MGLY to `gcpy/benchmark/modules/benchmark_categories.yml`
 
 ### Changed
 - Bumped `pypdf` to version 6.7.1 in `setup.py` and environment files

--- a/gcpy/benchmark/modules/benchmark_categories.yml
+++ b/gcpy/benchmark/modules/benchmark_categories.yml
@@ -204,6 +204,7 @@ FullChemBenchmark:
       - CH2O
       - GLYC
       - GLYX
+      - MGLY
       - HPALDs
       - MACR
       - RCHO

--- a/gcpy/benchmark/modules/benchmark_funcs.py
+++ b/gcpy/benchmark/modules/benchmark_funcs.py
@@ -260,10 +260,6 @@ def create_total_emissions_table(
         # =============================================================
         for v in varnames:
 
-            # KLUDGE, skip InvAFCID due to a file error in GCHP
-            if "InvAFCID" in v:
-                continue
-
             if "Inv" in template:
                 spc_name = v.split("_")[1]
             else:

--- a/gcpy/benchmark/modules/emission_inventories.yml
+++ b/gcpy/benchmark/modules/emission_inventories.yml
@@ -1,22 +1,19 @@
 FullChemBenchmark:
   AEIC: Tg
   AFCID: Tg
-  APEI: Tg
   C2H62010: Tg
   CEDS: Tg
   CEDSship: Tg
-  DEAD: Tg
   DustL23M: Tg
   DICEAfrica: Tg
   GEIAnatural: Tg
   GFED: Tg
+  #GFAS: Tg
   GTChlorine: Tg
   IODINE: Tg
   LIANG: Tg
   LIGHTNOX: Tg
   MEGAN: Tg
-  MIX: Tg
-  NEI2011: Tg
   ORDONEZ: Tg
   PARANOX: Tg
   PLANTDECAY: Tg

--- a/gcpy/benchmark/modules/emission_species.yml
+++ b/gcpy/benchmark/modules/emission_species.yml
@@ -41,6 +41,7 @@ FullChemBenchmark:
   HCl: Tg
   HCOOH: Tg
   HNO3: Tg
+  HONO: Tg
   ISOP: Tg
   LIMO: Tg
   MACR: Tg
@@ -52,6 +53,7 @@ FullChemBenchmark:
   MTPA: Tg
   MTPO: Tg
   MVK: Tg
+  NAP: Tg
   NH3: Tg
   'NO': Tg  # Quotes are necessary, otherwise YAML interprets NO as False
   NO2: Tg


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update

In this PR we have done the following:

1. Removed the hotfix to skip `InvAFCID` diagnostics, which was originally necessary due to a bug in GCHP HISTORY.rc files. This bug has since been fixed (see PR https://github.com/geoschem/geos-chem/pull/3260), which has rendered the hotfix obosolete.

2. Removed inventories no longer used in benchmark simulations from the FullChemBenchmark list in `gcpy/benchmark/modules/emission_inventories.yml`.  Also added a commented-out tag for GFAS (for future use).

3. Added HONO and NAP species to the FullChemBenchmark list in `gcpy/benchmark/modules/emission_species.yml`.

4. Added MGLY to `gcpy/benchmark/modules/benchmark_categories.yml` under "Secondary Organics" -> "Aldehydes".

### Expected changes

1. Will restore `InvAFCID` diagnostics to the emission inventories table.

2. Will prevent messages such as:
```console
No emissions found for APEI ... skippping
No emissions found for DICEAfrica ... skippping
No emissions found for MIX ... skippping
No emissions found for NEI2011 ... skippping
```

3. Will include HONO and NAP in the total emissions mass table.

4. Will eliminate this warning message:
```console
Warning: species MGLY has emissions diagnostics but is not in benchmark_categories.yml
```

### Related GitHub issue
- See https://github.com/geoschem/geos-chem/pull/3260