### PR TITLE
Fixed DeprecationWarning in single_panel.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Allow using a template at different grid resolutions in `gcpy/regrid_restart_file.py`
 - Implemented a workaround in `gcpy/regrid.py` to allow use of either `np.product` or `np.prod` depending on the Numpy version
+- Fixed `DeprecationWarning` in `single_panel.py` that occurs with numpy >=2.0
 
 ### Removed
 - Removed Python 3.9 from the GitHub Actions that try to build a Python environment; This version is now de-supported

--- a/gcpy/plot/single_panel.py
+++ b/gcpy/plot/single_panel.py
@@ -456,22 +456,22 @@ def single_panel(
                 if len(minlon_i) == 0:
                     minlon_i = 0
                 else:
-                    minlon_i = int(minlon_i)
+                    minlon_i = int(minlon_i[0])
                 maxlon_i = np.where(grid['lon_b']==closest_maxlon)[0]
                 if len(maxlon_i) == 0:
                     maxlon_i = -1
                 else:
-                    maxlon_i = int(maxlon_i)
+                    maxlon_i = int(maxlon_i[0])
                 minlat_i = np.where(grid['lat_b']==closest_minlat)[0]
                 if len(minlat_i) == 0:
                     minlat_i = 0
                 else:
-                    minlat_i = int(minlat_i)
+                    minlat_i = int(minlat_i[0])
                 maxlat_i = np.where(grid['lat_b']==closest_maxlat)[0]
                 if len(maxlat_i) == 0:
                     maxlat_i = -1
                 else:
-                    maxlat_i = int(maxlat_i)
+                    maxlat_i = int(maxlat_i[0])
                 plot_vals = plot_vals[minlat_i:maxlat_i+1,
                                       minlon_i:maxlon_i+1]
             # Create a lon/lat plot


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca (Harvard) and Yuanjian Zhang (WashU)

### Describe the update
This is the companion PR to #424, in which @yuanjianz noticed that a DeprecationWarning was being thrown when using Numpy 2.0+.  
```console
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
```
The issue is that Numpy 2.0+ no longer allows you to cast an entire array to int.  You must first take a scalar value and then cast.

### Expected changes
This fix will remove the DeprecationWarning.

### Related Github Issue
- Closes #424 
