### PR TITLE
Fixed bug in get_grid_extents affecting zonal mean plotting of data on halfpolar grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `pytest=8.3.4` as a dependency to environment files
 - Added several unit tests in `gcpy/tests` as well as a GitHub Action to run them on pushes and pull requests
 - Added `is_nearly_constant` function to `gcpy/util.py`
+- Added `pytest.ini` to filter benign warnings (numpy/ESMF ABI notice, xesmf array-contiguity notices) out of the test suite output
 
 ### Changed
 - Bumped `pypdf` to version 6.7.1 in `setup.py` and environment files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Passed `spcdb_files` as the 7th argument (following `dev_interval`) to `make_benchmark_operations_budget`, where missing
 - Passed `colname` as the 5th argument to `make_benchmark_collection_2d_var_plots` and `make_benchmark_collection_3d_var_plots`
 - Fixed an issue that caused striping when plotting zonal mean fields that are are nearly constant
+- Fixed `get_grid_extents` in `gcpy/grid.py` to snap pole-cutoff latitude grids to +/-90 degrees instead of an arbitrary 1-degree offset, which caused zonal mean plots of sub-1-degree-resolution grids (e.g. HEMCO diagnostics) to fail
 
 ### Removed
 - Removed Python 3.9 from the GitHub Actions that try to build a Python environment; This version is now de-supported.

--- a/gcpy/grid.py
+++ b/gcpy/grid.py
@@ -263,12 +263,19 @@ def get_grid_extents(data, edges=True):
 
         lat = np.sort(lat)
         minlat = np.min(lat)
-        if abs(abs(lat[1]) - abs(lat[0])) != abs(abs(lat[2]) - abs(lat[1])):
-            #pole is cutoff
-            minlat = minlat - 1
+        if not np.isclose(
+                abs(abs(lat[1]) - abs(lat[0])),
+                abs(abs(lat[2]) - abs(lat[1]))):
+            # pole is cutoff (half-polar boundary cell): snap to the
+            # true pole rather than padding by an arbitrary constant,
+            # which breaks for any resolution other than the one it
+            # was tuned for (see GitHub issue #425)
+            minlat = -90
         maxlat = np.max(lat)
-        if abs(abs(lat[-1]) - abs(lat[-2])) != abs(abs(lat[-2]) - abs(lat[-3])):
-            maxlat = maxlat + 1
+        if not np.isclose(
+                abs(abs(lat[-1]) - abs(lat[-2])),
+                abs(abs(lat[-2]) - abs(lat[-3]))):
+            maxlat = 90
         # add longitude res to max longitude
         lon = np.sort(lon)
         minlon = np.min(lon)

--- a/gcpy/tests/test_grid.py
+++ b/gcpy/tests/test_grid.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for gcpy.grid, focused on the "pole cutoff" latitude grid
+handling in get_grid_extents() and make_grid_ll() implicated in
+GitHub issue #425 (zonal mean plots of sub-1-degree-resolution
+lat/lon grids, e.g. HEMCO diagnostics, failed with a pcolormesh
+shape-mismatch error).
+"""
+import numpy as np
+import xarray as xr
+
+from gcpy.grid import get_grid_extents, make_grid_ll
+from gcpy.plot.single_panel import single_panel
+
+# Reproduce the pole-cutoff 0.5x0.625 grid described in the issue:
+# lat centers [-89.875, -89.5, ..., 89.5, 89.875] (a narrower boundary
+# band than the 0.5 degree interior spacing), 361 centers total.
+LLRES = "0.5x0.625"
+_INTERIOR_LAT = np.round(np.arange(-89.5, 89.5 + 1e-6, 0.5), 8)
+POLE_CUTOFF_LAT = np.concatenate(([-89.875], _INTERIOR_LAT, [89.875]))
+POLE_CUTOFF_LON = np.round(np.arange(-180, 180, 0.625), 8)
+
+
+def test_get_grid_extents_snaps_pole_cutoff_lat_to_90():
+    """
+    get_grid_extents() should snap a detected pole-cutoff latitude
+    band to the true pole (+/-90) rather than an arbitrary
+    resolution-independent offset (GitHub issue #425).
+    """
+    ds = xr.Dataset(
+        coords={"lat": POLE_CUTOFF_LAT, "lon": POLE_CUTOFF_LON})
+
+    minlon, maxlon, minlat, maxlat = get_grid_extents(ds)
+
+    assert (minlon, maxlon, minlat, maxlat) == (-180, 180, -90, 90)
+
+
+def test_make_grid_ll_pole_cutoff_extent_has_no_duplicate_edges():
+    """
+    make_grid_ll() should return the correct number of latitude edges
+    (362, i.e. 361 cell centers) for a 0.5x0.625 grid, with no
+    duplicate/degenerate edges at the poles. Before the fix, an
+    overshot pole-cutoff extent of (-90.875, 90.875) produced 365
+    edges with triplicate values at each pole (GitHub issue #425).
+    """
+    extent = list(get_grid_extents(
+        xr.Dataset(coords={"lat": POLE_CUTOFF_LAT, "lon": POLE_CUTOFF_LON})
+    ))
+
+    llgrid = make_grid_ll(LLRES, extent, extent)
+
+    assert llgrid["lat_b"].shape == (362,)
+    assert llgrid["lat"].shape == (361,)
+    assert np.unique(llgrid["lat_b"]).size == llgrid["lat_b"].size
+
+
+def test_single_panel_zonal_mean_pole_cutoff_grid():
+    """
+    single_panel(..., plot_type="zonal_mean") should not raise a
+    pcolormesh shape-mismatch error when plotting data on a
+    pole-cutoff lat/lon grid (GitHub issue #425). Uses a 47-level
+    grid so get_vert_grid() resolves pressure edges without requiring
+    explicit AP/BP parameters.
+    """
+    nlev = 47
+    data = xr.DataArray(
+        np.random.rand(nlev, POLE_CUTOFF_LAT.size, POLE_CUTOFF_LON.size),
+        dims=["lev", "lat", "lon"],
+        coords={
+            "lev": np.arange(1, nlev + 1),
+            "lat": POLE_CUTOFF_LAT,
+            "lon": POLE_CUTOFF_LON,
+        },
+    )
+
+    plot = single_panel(data, plot_type="zonal_mean")
+
+    assert plot is not None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+filterwarnings =
+    # Benign false-positive from compiled C-extension deps (e.g. ESMF/xesmf)
+    # built against a different numpy ABI than the installed numpy; not
+    # something GCPy code can fix directly.
+    ignore:numpy.ndarray size changed.*:RuntimeWarning
+    # xesmf's internal steps want different array memory layouts
+    # (F_CONTIGUOUS in one place, C_CONTIGUOUS in another) for the same
+    # array, so no single layout choice on our end avoids both; these
+    # are performance notices only, not correctness issues.
+    ignore:Input array is not F_CONTIGUOUS.*:UserWarning
+    ignore:Input array is not C_CONTIGUOUS.*:UserWarning


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update 
This PR fixes the issue raised by @yuanjianz in #425.  In that issue, it was made known that creating a zonal mean plot from a netCDF file with a "halfpolar" lat-lon grid (lat centers like `[-89.875, -89.5, ..., 89.5, 89.875]`) failed with:

```console
Dimensions of C (47, 361) should be one smaller than X(365) and Y(48) while using shading='flat' see help(pcolormesh)
```
The root cause is confirmed to be in `get_grid_extents()` in `gcpy/grid.py`:

```python
# gcpy/grid.py, lines 264-271
lat = np.sort(lat)
minlat = np.min(lat)
if abs(abs(lat[1]) - abs(lat[0])) != abs(abs(lat[2]) - abs(lat[1])):
    #pole is cutoff
    minlat = minlat - 1
maxlat = np.max(lat)
if abs(abs(lat[-1]) - abs(lat[-2])) != abs(abs(lat[-2]) - abs(lat[-3])):
    maxlat = maxlat + 1
```
When the boundary latitude band is narrower than the interior spacing, this code pads `minlat` and `maxlat`by a **hardcoded 1 degree** instead of snapping to the true physical pole (`±90`). For coarse legacy resolutions (e.g. GC Classic  4x5, where this branch typically doesn't even trigger because centers already sit exactly at ±90) this happens to be harmless. But for any finer resolution — 0.5x0.625 etc. — a flat 1° overshoots the actual half-cell width, so `get_grid_extents` returns e.g. `(-90.875, 90.875)` instead of `(-90, 90)`.

The fix: make `get_grid_extents()` snap to the physically correct `±90` pole value instead of an arbitrary resolution-independent constant, and make the boundary-spacing comparison tolerant of floating-point noise (real NetCDF lat coordinates, especially those stored as float32, won't compare exactly equal even when uniformly spaced).

#### Additional updates:
- Added unit tests to catch this type of error `gcpy/tests/grid.py`
- Added `gcpy/tests/pytest.ini` with instructions to squelch benign warnings from unit test output

### Expected changes
Function `get_grid_extents` will set the max and min latitudes of halfpolar grids to +/-90 degrees north.

### Related Github Issue
- Closes #425 

### AI disclosure
Prepared by Claude Code, verified by @yantosca