### PR TITLE
Fix precision issue causing infinity CH4 and MCF lifetimes in OH metrics benchmark tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Bumped pytest to 9.0.3 in `_setup.py` and environment files; Updated documentation accordingly
 
+### Fixed
+- Fixed a float32 overflow in `gcpy/benchmark/modules/oh_metrics.py` that produced `inf` global airmass, CH4 lifetime, and MCF lifetime values
+
 ## [1.8.0] - 2026-08-10
 ### Added
 - Added HONO and NAP to `gcpy/benchmark/modules/emission_species.yml`

--- a/gcpy/benchmark/modules/oh_metrics.py
+++ b/gcpy/benchmark/modules/oh_metrics.py
@@ -132,7 +132,7 @@ def total_airmass(data):
         Total atmospheric air mass [molecules].
     """
 
-    airmass_kg = np.nansum(data["AirMassColumnFull"].values)
+    airmass_kg = np.nansum(data["AirMassColumnFull"].values, dtype=np.float64)
     airmass_m = airmass_kg * (AVOGADRO / MW_AIR_kg)
 
     return airmass_kg, airmass_m
@@ -158,7 +158,10 @@ def global_mean_oh(data, airmass_kg, mw_oh_kg):
     """
     # Divide out total airmass to get total mean OH concentration [kg m-3]
     # Then convert mean OH from [kg m-3] to [1e5 molec cm-3]
-    mean_oh = np.nansum(data["OHwgtByAirMassColumnFull"].values)
+    mean_oh = np.nansum(
+        data["OHwgtByAirMassColumnFull"].values,
+        dtype=np.float64
+    )
     mean_oh = mean_oh / airmass_kg
     mean_oh *= (AVOGADRO / (mw_oh_kg * 1.0e6)) * 1.0e-5
 
@@ -189,8 +192,14 @@ def lifetimes_wrt_oh(data, airmass_m):
     s_per_yr = np.float64(86400.0) * np.float64(365.25)
 
     # Loss of OH by CH4+OH and MCF+OH reactions [molec]
-    oh_loss_by_ch4 = np.nansum(data["LossOHbyCH4columnTrop"].values)
-    oh_loss_by_mcf = np.nansum(data["LossOHbyMCFcolumnTrop"].values)
+    oh_loss_by_ch4 = np.nansum(
+        data["LossOHbyCH4columnTrop"].values,
+        dtype=np.float64
+    )
+    oh_loss_by_mcf = np.nansum(
+        data["LossOHbyMCFcolumnTrop"].values,
+        dtype=np.float64
+    )
 
     # CH4 and MCF lifetimes against OH [years]
     ch4_life_wrt_oh = (airmass_m / oh_loss_by_ch4) / s_per_yr


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR fixes an an issue in the OH metrics benchmark table.  Under certain conditions, the `airmass_m` variable (which is `gcpy/benchmark/modules/oh_metrics.py` can overflow to infinity.  This is because the `airmass_m` variable inherits the type of the data.  If the data is stored float32, then this can lead to an infinity if the sum of airmass in molecules exceeds ~1e38.

The fix in this adds a `dtype=np.float64` to the `np.nansum` function.  This will cause the summation to be done in float64 regardless of the type of the input data.

### Expected changes

#### Before the fix
```console
###############################################################################
### OH Metrics
### Ref = gchp.14.8.0-alpha.11
### Dev = gchp.14.8.0-alpha.12
###############################################################################

------------------------------------------------------------
Global mass-weighted OH concentration [10^5 molec cm^-3]
------------------------------------------------------------
Ref      : 12.86017513275
Dev      : 13.04171085358
Abs diff :  0.18153572083
%   diff :  1.411612

------------------------------------------------------------
CH3CCl3 (aka MCF) lifetime w/r/t tropospheric OH [years]
------------------------------------------------------------
Ref      :       inf
Dev      :       inf
Abs diff :       nan
%   diff :       nan

------------------------------------------------------------
CH4 lifetime w/r/t tropospheric OH [years]
------------------------------------------------------------
Ref      :       inf
Dev      :       inf
Abs diff :       nan
%   diff :       nan
```
#### After the fix
```console
###############################################################################
### OH Metrics
### Ref = gchp.14.8.0-alpha.11
### Dev = gchp.14.8.0-alpha.12
###############################################################################

------------------------------------------------------------
Global mass-weighted OH concentration [10^5 molec cm^-3]
------------------------------------------------------------
Ref      : 12.86017418123
Dev      : 13.04170908978
Abs diff :  0.18153490855
%   diff :  1.411605

------------------------------------------------------------
CH3CCl3 (aka MCF) lifetime w/r/t tropospheric OH [years]
------------------------------------------------------------
Ref      :  4.889533
Dev      :  4.816989
Abs diff : -0.072543
%   diff : -1.483648

------------------------------------------------------------
CH4 lifetime w/r/t tropospheric OH [years]
------------------------------------------------------------
Ref      :  8.262788
Dev      :  8.143407
Abs diff : -0.119381
%   diff : -1.444808
```

## AI disclosure
Fix proposed by Claude Code, verified by @yantosca.