### PR TITLE
Build GCPy environment with Python 3.14

### DIFF
--- a/.github/workflows/build-gcpy-environment-py314.yml
+++ b/.github/workflows/build-gcpy-environment-py314.yml
@@ -1,0 +1,46 @@
+---
+#
+# GitHub action to build the GCPy production environment (Python 3.14)
+# See: https://github.com/marketplace/actions/setup-micromamba
+#
+name: build-gcpy-environment-py314
+
+on:
+  push:
+    branches: [ "main", "dev", "dependabot/*" ]
+  pull_request:
+    # These must be a subset of the branches above
+    branches: [ "main", "dev", "dependabot/*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Checkout the GCPy repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create "gcpy_env" environment
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          micromamba-version: 'latest'
+          environment-file: docs/environment_files/gcpy_environment_py314.yml
+          init-shell: bash
+          cache-environment: false
+          generate-run-shell: true
+          post-cleanup: 'all'
+
+      - name: Test if "import gcpy" works
+        run: python -c "import gcpy"
+        shell: micromamba-shell {0}
+
+      - name: Test if we can create a plot
+        run: python -m gcpy.examples.plotting.create_test_plot
+        shell: micromamba-shell {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `run_benchmark*` routines to read `yaxis_units` from YAML files and to pass its value to relevant benchmark routines
 - Updated ReadTheDocs documentation for the GCPy environment with Python 3.14
 - Bumped pypdf to 6.16.1 and updated documentation accordingly
+- Bumped pytest to 9.0.3 in `_setup.py` and environment files; Updated documentation accordingly
+- Prevented `RuntimeWarning` messages from occurring in `gcpy/file_regrid.py`
 
 ### Fixed
 - Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Passed kwarg `yaxis_units` down from `compare_zonal_mean` to `six_plot` to `single_panel`
 - Updated `run_benchmark*` routines to read `yaxis_units` from YAML files and to pass its value to relevant benchmark routines
 - Updated ReadTheDocs documentation for the GCPy environment with Python 3.14
+- Bumped pypdf to 6.16.1 and updated documentation accordingly
 
 ### Fixed
 - Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - `gcpy/benchmark/config/*.yml`
   - `gcpy/benchmark/cloud/*.yml`
   - `gcpy/examples/diagnostics/compare_diags.yml`
+- Added `docs/environment_files/gcpy_environment_py314.yml`
+- Added GitHub Action `build-gcpy-environment-py314.yml` to build and test the GCPy environment with Python 3.14
 
 ### Changed
 - Replaced the hardcoded `rtol` and `atol` defaults of `ref_equals_dev` in `gcpy/plot/six_plot.py` with the `NOISE_REL_TOL` and `RATIO_ABS_TOL` constants from `gcpy/plot/core.py`
@@ -31,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated paths to model vs observations data in 1-year benchmark yaml files
 - Passed kwarg `yaxis_units` down from `compare_zonal_mean` to `six_plot` to `single_panel`
 - Updated `run_benchmark*` routines to read `yaxis_units` from YAML files and to pass its value to relevant benchmark routines
+- Updated ReadTheDocs documentation for the GCPy environment with Python 3.14
 
 ### Fixed
 - Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids
@@ -40,14 +43,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed blank/white Ref and Dev panels for small-magnitude fields in zonal-mean plots in `gcpy/plot/core.py`
 - Fixed blank/white difference panels for small-magnitude fields (e.g. `EmisCO_Aircraft`, ~1e-13 kg/m2/s) in zonal-mean plots; `normalize_colors` in `gcpy/plot/core.py` now scales its absolute tolerance to the magnitude of the Ref and Dev data instead of using a fixed `atol=1e-7`, which had no relationship to the units of the field
 - Fixed the misleading -1..1 colorbar shown on a difference panel whose color scale was collapsed; such panels are now labeled "Differences negligible throughout domain"
-- Fixed uninformative ratio-panel colorbar labels: a ratio panel now reports "Ref is zero throughout domain" or "Dev is zero throughout domain" instead of the generic "Undefined throughout domain" or "Zero throughout domain", so that a blank ratio row can be reconciled with a populated difference row
-- Fixed `fracdiff_is_all_nan` in `gcpy/plot/compare_single_level.py`, whose `or ref_is_all_zero` clause blanked both fractional-difference panels of a diff-of-diffs plot whenever the two Ref files were identical
-- Fixed `is_nearly_constant` in `gcpy/util.py` to honor a masked array's mask instead of reading the fill value underneath it, which stopped the "Ref and Dev equal throughout domain" label from appearing on ratio panels of sparse fields
-- Fixed `get_nan_mask` in `gcpy/util.py`, which built its mask from the original array rather than the filled one and so masked nothing at all; it also no longer fails on all-NaN input
-- Fixed blank ratio colorbars (no gradient, ticks, or label) on zonal-mean plots where Ref and Dev are both zero; `colorbar_for_all_zero_or_nan` placed its tick at 0.0, which lies outside the [0.5, 2.0] range of a ratio panel norm and stretched the colorbar axes
-- Fixed `vmin_vmax_for_absdiff_plots` in `gcpy/plot/six_plot.py` to use `np.nanpercentile` instead of `np.percentile`, so that a single NaN no longer collapses the restricted-range difference panel to a flat color scale while it still draws the real (saturated) data
-- Fixed ratio panels rendering numerical noise as saturated color in both `gcpy/plot/compare_zonal_mean.py` and `gcpy/plot/compare_single_level.py`; where a field is really zero, regridding leaves a tiny residue in both Ref and Dev, and dividing one by the other gave an arbitrary ratio.  Such cells are now masked
-- Fixed the fallback `normalize_colors` call in `gcpy/plot/single_panel.py`, which omitted `use_tolerance` and so applied the near-constant tolerance to single-level data, contrary to the scoping decided in GitHub issue #439
+- Fixed ratio panel plots to Ratio to report "Ref is zero throughout domain" or "Dev is zero throughout domain" instead of a more generic label
+- Fixed `fracdiff_is_all_nan` in `gcpy/plot/compare_single_level.py`, whose `or ref_is_all_zero` clause blanked both fracdiff panels of a diff-of-diffs plot whenever the two Ref files were identical
+- Fixed `is_nearly_constant` in `gcpy/util.py` to honor a masked array's mask instead of reading the fill value underneath it
+- Fixed `get_nan_mask` in `gcpy/util.py`, which built its mask from the original array rather than the filled one and so masked nothing at all
+- Fixed blank ratio colorbars (no gradient, ticks, or label) on zonal-mean plots where Ref and Dev are both zero
+- Fixed `vmin_vmax_for_absdiff_plots` in `gcpy/plot/six_plot.py` to use `np.nanpercentile` instead of `np.percentile`
+- Fixed ratio panels rendering numerical noise as saturated color in both `gcpy/plot/compare_zonal_mean.py` and `gcpy/plot/compare_single_level.py`
+- Fixed the fallback `normalize_colors` call in `gcpy/plot/single_panel.py`, which omitted `use_tolerance`
+- Fixed `gcpy/examples/plotting/create_test_plot.py` to import `gcpy.plot` directly instead of relying on that side effect
 
 ### Removed
 - Removed the Advected column from the wiki tables in `gcpy/benchmark/modules/benchmark_species_changes.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed ratio panels rendering numerical noise as saturated color in both `gcpy/plot/compare_zonal_mean.py` and `gcpy/plot/compare_single_level.py`
 - Fixed the fallback `normalize_colors` call in `gcpy/plot/single_panel.py`, which omitted `use_tolerance`
 - Fixed `gcpy/examples/plotting/create_test_plot.py` to import `gcpy.plot` directly instead of relying on that side effect
+- Silenced benign `findfont: Failed to find font weight ...` messages from Matplotlib's `font_manager` logger in `gcpy/plot/core.py`
 
 ### Removed
 - Removed the Advected column from the wiki tables in `gcpy/benchmark/modules/benchmark_species_changes.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bumped pypdf to 6.16.1 and updated documentation accordingly
 - Bumped pytest to 9.0.3 in `_setup.py` and environment files; Updated documentation accordingly
 - Prevented `RuntimeWarning` messages from occurring in `gcpy/file_regrid.py`
+- Bumped pip to 26.2.1 and updated documentation accordingly
 
 ### Fixed
 - Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids

--- a/docs/environment_files/gcpy_environment_py312.yml
+++ b/docs/environment_files/gcpy_environment_py312.yml
@@ -33,7 +33,7 @@ dependencies:
   - pylint               =3.2.2      # Python linter
   - pyproj               =3.6.1      # Python map projections library
   - python               =3.12.0     # Python language
-  - pypdf                =6.7.1      # PDF utilities (bookmarks, etc.)
+  - pypdf                =6.16.1     # PDF utilities (bookmarks, etc.)
   - pytest               =9.0.3      # Testing framework
   - requests             =2.33.0     # HTTP library
   - scipy                =1.13.1     # Scientific python package

--- a/docs/environment_files/gcpy_environment_py312.yml
+++ b/docs/environment_files/gcpy_environment_py312.yml
@@ -29,7 +29,7 @@ dependencies:
   - netcdf-fortran       =4.6.1      # Python wrapper for netCDF-Fortran
   - numpy                =1.26.4     # Optimized mathematical functions
   - pandas               =2.2.2      # Tables/timeseries manipulation
-  - pip                  =26.1.2     # Install packages from PyPi
+  - pip                  =26.2.1     # Install packages from PyPi
   - pylint               =3.2.2      # Python linter
   - pyproj               =3.6.1      # Python map projections library
   - python               =3.12.0     # Python language

--- a/docs/environment_files/gcpy_environment_py313.yml
+++ b/docs/environment_files/gcpy_environment_py313.yml
@@ -33,7 +33,7 @@ dependencies:
   - pylint               =3.3.4      # Python linter
   - pyproj               =3.7.1      # Python map projections library
   - python               =3.13       # Python language
-  - pypdf                =6.7.1      # PDF utilities (bookmarks, etc.)
+  - pypdf                =6.16.1     # PDF utilities (bookmarks, etc.)
   - pytest               =9.0.3      # Testing framework
   - requests             =2.33.0     # HTTP library
   - scipy                =1.15.2     # Scientific python package

--- a/docs/environment_files/gcpy_environment_py313.yml
+++ b/docs/environment_files/gcpy_environment_py313.yml
@@ -29,7 +29,7 @@ dependencies:
   - netcdf-fortran       =4.6.1      # Python wrapper for netCDF-Fortran
   - numpy                =2.1.3      # Optimized mathematical functions
   - pandas               =2.2.3      # Tables/timeseries manipulation
-  - pip                  =26.1.2     # Install packages from PyPi
+  - pip                  =26.2.1     # Install packages from PyPi
   - pylint               =3.3.4      # Python linter
   - pyproj               =3.7.1      # Python map projections library
   - python               =3.13       # Python language

--- a/docs/environment_files/gcpy_environment_py314.yml
+++ b/docs/environment_files/gcpy_environment_py314.yml
@@ -1,0 +1,54 @@
+---
+# ======================================================================
+# GCPy environment file (based on Python 3.14)
+#
+# If you wish to build a Mamba/Conda environment with the dependencies
+# for GCPy, use this command:
+#
+# $ mamba env create -n gcpy_env --file=/path/to/gcpy/environment.yml
+# =====================================================================
+name: gcpy_env
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  #
+  # GCpy dependencies
+  #
+  - cartopy              =0.25.0     # Geospatial data processing
+  - cf_xarray            =0.11.3     # CF conventions for xarray
+  - dask                 =2026.7.1   # Parallel library; backend for xarray
+  - esmf                 =8.9.1      # Earth System Model Framework
+  - esmpy                =8.9.1      # Python wrapper for ESMF
+  - gridspec             =0.1.0      # Define Earth System Model grids
+  - ipython              =9.16.1     # Interactive Python (used by Jupyter)
+  - joblib               =1.5.3      # Parallelize python code
+  - jupyter              =1.1.1      # Jupyter Notebook
+  - matplotlib           =3.11.1     # Creates plots and visualizations
+  - netcdf4              =1.7.4      # Python wrapper for netCDF
+  - netcdf-fortran       =4.6.3      # Python wrapper for netCDF-Fortran
+  - numpy                =2.5.2      # Optimized mathematical functions
+  - pandas               =3.0.5      # Tables/timeseries manipulation
+  - pip                  =26.2.1     # Install packages from PyPi
+  - pylint               =4.0.7      # Python linter
+  - pyproj               =3.7.2      # Python map projections library
+  - python               =3.14       # Python language
+  - pypdf                =6.16.1     # PDF utilities (bookmarks, etc.)
+  - pytest               =9.1.1      # Testing framework
+  - requests             =2.34.2     # HTTP library
+  - scipy                =1.18.0     # Scientific python package
+  - sparselt             =0.1.3      # Regridding earth system model data
+  - tabulate             =0.10.0     # Pretty-printing for column data
+  - tk                   =8.6.13     # Tcl/tk library
+  - xarray               =2026.7.0   # Read data from netCDF etc files
+  - xesmf                =0.9.2      # Universal regridder
+  #
+  # ReadTheDocs dependencies
+  #
+  - sphinx               =9.1.0      # Sphinx package
+  - sphinx_rtd_theme     =3.1.0      # ReadTheDocs theme
+  - sphinxcontrib-bibtex =2.7.0      # Bibliography extension
+  - sphinx-autobuild     =2025.8.25  # Builds docs & displays to browser
+  - myst-parser          =5.1.0      # Formerly recommonmark
+  - docutils             =0.22.4     # Processes plaintext to other formats
+  - jinja2               =3.1.6      # Templating

--- a/docs/environment_files/gcpy_environment_py314.yml
+++ b/docs/environment_files/gcpy_environment_py314.yml
@@ -15,43 +15,45 @@ dependencies:
   #
   # GCpy dependencies
   #
-  - cartopy              =0.25.0     # Geospatial data processing
-  - cf_xarray            =0.11.3     # CF conventions for xarray
-  - dask                 =2026.7.1   # Parallel library; backend for xarray
-  - esmf                 =8.9.1      # Earth System Model Framework
-  - esmpy                =8.9.1      # Python wrapper for ESMF
-  - gridspec             =0.1.0      # Define Earth System Model grids
-  - ipython              =9.16.1     # Interactive Python (used by Jupyter)
-  - joblib               =1.5.3      # Parallelize python code
-  - jupyter              =1.1.1      # Jupyter Notebook
-  - matplotlib           =3.11.1     # Creates plots and visualizations
-  - netcdf4              =1.7.4      # Python wrapper for netCDF
-  - netcdf-fortran       =4.6.3      # Python wrapper for netCDF-Fortran
-  - numpy                =2.5.2      # Optimized mathematical functions
-  - pandas               =3.0.5      # Tables/timeseries manipulation
-  - pip                  =26.2.1     # Install packages from PyPi
-  - pylint               =4.0.7      # Python linter
-  - pyproj               =3.7.2      # Python map projections library
-  - python               =3.14=*cp314 # Python language (standard, GIL-enabled build;
-                                       # avoids the free-threaded "cp314t" build, since
-                                       # cftime and other C-extension dependencies have
-                                       # not yet declared free-threading support)
-  - pypdf                =6.16.1     # PDF utilities (bookmarks, etc.)
-  - pytest               =9.1.1      # Testing framework
-  - requests             =2.34.2     # HTTP library
-  - scipy                =1.18.0     # Scientific python package
-  - sparselt             =0.1.3      # Regridding earth system model data
-  - tabulate             =0.10.0     # Pretty-printing for column data
-  - tk                   =8.6.13     # Tcl/tk library
-  - xarray               =2026.7.0   # Read data from netCDF etc files
-  - xesmf                =0.9.2      # Universal regridder
+  - cartopy              =0.25.0      # Geospatial data processing
+  - cf_xarray            =0.11.3      # CF conventions for xarray
+  - dask                 =2026.7.1    # Parallel library; backend for xarray
+  - esmf                 =8.9.1       # Earth System Model Framework
+  - esmpy                =8.9.1       # Python wrapper for ESMF
+  - gridspec             =0.1.0       # Define Earth System Model grids
+  - ipython              =9.16.1      # Interactive Python (used by Jupyter)
+  - joblib               =1.5.3       # Parallelize python code
+  - jupyter              =1.1.1       # Jupyter Notebook
+  - matplotlib           =3.11.1      # Creates plots and visualizations
+  - netcdf4              =1.7.4       # Python wrapper for netCDF
+  - netcdf-fortran       =4.6.3       # Python wrapper for netCDF-Fortran
+  - numpy                =2.5.2       # Optimized mathematical functions
+  - pandas               =3.0.5       # Tables/timeseries manipulation
+  - pip                  =26.2.1      # Install packages from PyPi
+  - pylint               =4.0.7       # Python linter
+  - pyproj               =3.7.2       # Python map projections library
+  - python               =3.14=*cp314 # Python language (standard,
+                                      #  GIL-enabled build; avoids the
+                                      #  free-threaded "cp314t" build, since
+                                      #  cftime and other C-extension
+                                      #  dependencies have not yet
+                                      #  declared free-threading support)
+  - pypdf                =6.16.1      # PDF utilities (bookmarks, etc.)
+  - pytest               =9.1.1       # Testing framework
+  - requests             =2.34.2      # HTTP library
+  - scipy                =1.18.0      # Scientific python package
+  - sparselt             =0.1.3       # Regridding earth system model data
+  - tabulate             =0.10.0      # Pretty-printing for column data
+  - tk                   =8.6.13      # Tcl/tk library
+  - xarray               =2026.7.0    # Read data from netCDF etc files
+  - xesmf                =0.9.2       # Universal regridder
   #
   # ReadTheDocs dependencies
   #
-  - sphinx               =9.1.0      # Sphinx package
-  - sphinx_rtd_theme     =3.1.0      # ReadTheDocs theme
-  - sphinxcontrib-bibtex =2.7.0      # Bibliography extension
-  - sphinx-autobuild     =2025.8.25  # Builds docs & displays to browser
-  - myst-parser          =5.1.0      # Formerly recommonmark
-  - docutils             =0.22.4     # Processes plaintext to other formats
-  - jinja2               =3.1.6      # Templating
+  - sphinx               =9.1.0       # Sphinx package
+  - sphinx_rtd_theme     =3.1.0       # ReadTheDocs theme
+  - sphinxcontrib-bibtex =2.7.0       # Bibliography extension
+  - sphinx-autobuild     =2025.8.25   # Builds docs & displays to browser
+  - myst-parser          =5.1.0       # Formerly recommonmark
+  - docutils             =0.22.4      # Processes plaintext to other formats
+  - jinja2               =3.1.6       # Templating

--- a/docs/environment_files/gcpy_environment_py314.yml
+++ b/docs/environment_files/gcpy_environment_py314.yml
@@ -32,7 +32,10 @@ dependencies:
   - pip                  =26.2.1     # Install packages from PyPi
   - pylint               =4.0.7      # Python linter
   - pyproj               =3.7.2      # Python map projections library
-  - python               =3.14       # Python language
+  - python               =3.14=*cp314 # Python language (standard, GIL-enabled build;
+                                       # avoids the free-threaded "cp314t" build, since
+                                       # cftime and other C-extension dependencies have
+                                       # not yet declared free-threading support)
   - pypdf                =6.16.1     # PDF utilities (bookmarks, etc.)
   - pytest               =9.1.1      # Testing framework
   - requests             =2.34.2     # HTTP library

--- a/docs/source/Getting-Started-with-GCPy.rst
+++ b/docs/source/Getting-Started-with-GCPy.rst
@@ -109,8 +109,8 @@ GCPy requires several other Python packages, which are listed below.
      - 3.3.4
      - 4.0.7
    * - pypdf
-     - 6.4.0
-     - 6.4.0
+     - 6.16.1
+     - 6.16.1
      - 6.16.1
    * - pyproj
      - 3.6.1

--- a/docs/source/Getting-Started-with-GCPy.rst
+++ b/docs/source/Getting-Started-with-GCPy.rst
@@ -43,87 +43,115 @@ GCPy requires several other Python packages, which are listed below.
    * - Package
      - Version (Python 3.12)
      - Version (Python 3.13)
+     - Version (Python 3.14)
    * - `cartopy <https://scitools.org.uk/cartopy/docs/latest/>`_
      - 0.23.0
      - 0.24.0
+     - 0.25.0
    * - cf_xarray
      - 0.9.1
      - 0.10.0
+     - 0.11.3
    * - dask
      - 2025.3.0
      - 2025.3.0
+     - 2026.7.1
    * - esmf [#A]_ [#B]_
      - 8.6.1
      - 8.8.1
+     - 8.9.1
    * - `esmpy <https://www.earthsystemcog.org/projects/esmpy/>`_ [#A]_ [#B]_
      - 8.6.1
      - 8.8.1
+     - 8.9.1
    * - gridspec
+     - 0.1.0
      - 0.1.0
      - 0.1.0
    * - ipython
      - 8.25.0
      - 9.0.0
+     - 9.16.1
    * - `joblib <https://joblib.readthedocs.io/en/latest/>`_
      - 1.4.2
      - 1.4.2
+     - 1.5.3
    * - jupyter
      - 1.0.0
+     - 1.1.1
      - 1.1.1
    * - `matplotlib <https://matplotlib.org/>`_
      - 3.8.4
      - 3.10.1
+     - 3.11.1
    * - netcdf4
      - 1.6.5
      - 1.7.2
+     - 1.7.4
    * - netcdf-fortran
      - 4.6.1
      - 4.6.1
+     - 4.6.3
    * - `numpy <http://www.numpy.org/>`_
      - 1.26.4
      - 2.1.3
+     - 2.5.2
    * - `pandas <https://pandas.pydata.org/docs/>`_
      - 2.2.2
      - 2.2.3
+     - 3.0.5
    * - pip
      - 24.0
      - 25.0.1
+     - 26.2.1
    * - pylint
      - 3.2.2
      - 3.3.4
+     - 4.0.7
    * - pypdf
      - 6.4.0
      - 6.4.0
+     - 6.16.1
    * - pyproj
      - 3.6.1
      - 3.7.1
+     - 3.7.2
    * - pytest
      - 9.0.3
      - 9.0.3
+     - 9.1.1
    * - `python <https://www.python.org/>`_
      - 3.12.0
      - 3.13.0
+     - 3.14.0
    * - requests
      - 2.32.3
      - 2.32.3
+     - 2.34.2
    * - `scipy <http://www.scipy.org/>`_
      - 1.13.1
      - 1.15.2
+     - 1.18.0
    * - `sparselt <https://github.com/liambindle/sparselt>`_
+     - 0.1.3
      - 0.1.3
      - 0.1.3
    * - tabulate
      - 0.9.0
      - 0.9.0
+     - 0.10.0
    * - tk
+     - 8.6.13
      - 8.6.13
      - 8.6.13
    * - `xarray <http://xarray.pydata.org>`_
      - 2024.5.0
      - 2025.1.2
+     - 2026.7.0
    * - `xesmf <https://xesmf.readthedocs.io>`_
      - 0.8.5
      - 0.8.5
+     - 0.9.2
 
 .. rubric:: Notes
 
@@ -146,11 +174,14 @@ Ths file contains the package specifications listed above under the
 
 We also maintain a GCPy environment file for backwards compatibility
 with Python 3.12
-(:file:`docs/environment_files/gcpy_environment_py312.yml`).  However,
-we have not yet been able to construct a GCPy environment using Python
-3.14, due to conflicts in installing the :program:`esmf` and
-:program:`xesmf` packages.  We hope to be able to resolve this in the
-near future.
+(:file:`docs/environment_files/gcpy_environment_py312.yml`), as well as
+an environment file for Python 3.14
+(:file:`docs/environment_files/gcpy_environment_py314.yml`), which
+contains the package specifications listed above under the
+**Version (Python 3.14)** column.  Earlier releases of GCPy could not
+build a Python 3.14 environment due to conflicts in installing the
+:program:`esmf` and :program:`xesmf` packages; these have since been
+resolved upstream on `conda-forge <https://conda-forge.org/>`_.
 
 .. _install-methods:
 

--- a/docs/source/Getting-Started-with-GCPy.rst
+++ b/docs/source/Getting-Started-with-GCPy.rst
@@ -101,8 +101,8 @@ GCPy requires several other Python packages, which are listed below.
      - 2.2.3
      - 3.0.5
    * - pip
-     - 24.0
-     - 25.0.1
+     - 26.2.1
+     - 26.2.1
      - 26.2.1
    * - pylint
      - 3.2.2

--- a/gcpy/examples/diagnostics/__init__.py
+++ b/gcpy/examples/diagnostics/__init__.py
@@ -1,6 +1,3 @@
 """
 GCPy examples for processing model diagnostic output.
 """
-
-from .compare_diags import *
-from .check_gchp_emission_diags import *

--- a/gcpy/examples/dry_run/__init__.py
+++ b/gcpy/examples/dry_run/__init__.py
@@ -1,6 +1,3 @@
 """
 GCPy example script for the GEOS-Chem dry-run simulation.
 """
-
-from .download_data import *
-

--- a/gcpy/examples/grids/__init__.py
+++ b/gcpy/examples/grids/__init__.py
@@ -1,4 +1,3 @@
 """
 GCPy examples for working with horizontal and vertical grids.
 """
-from .display_gcclassic_grid_info import *

--- a/gcpy/examples/hemco/__init__.py
+++ b/gcpy/examples/hemco/__init__.py
@@ -1,6 +1,3 @@
 """
 GCPy examples related to HEMCO (The Harmonized Emissions Component).
 """
-from .format_hemco_demo import *
-from .make_hemco_sa_spec import *
-from .make_mask_file import *

--- a/gcpy/examples/plotting/__init__.py
+++ b/gcpy/examples/plotting/__init__.py
@@ -1,6 +1,3 @@
 """
 GCPy example scripts for plotting data.
 """
-from .create_test_plot import *
-from .plot_comparisons import *
-from .plot_single_panel import *

--- a/gcpy/examples/plotting/create_test_plot.py
+++ b/gcpy/examples/plotting/create_test_plot.py
@@ -17,7 +17,7 @@ Examples
 import numpy as np
 import xarray as xr
 import matplotlib.pyplot as plt
-import gcpy
+import gcpy.plot
 
 
 def main():

--- a/gcpy/examples/timeseries/__init__.py
+++ b/gcpy/examples/timeseries/__init__.py
@@ -1,5 +1,3 @@
 """
 GCPy example script for plotting timeseries data.
 """
-from .plot_timeseries import *
-

--- a/gcpy/examples/working_with_files/__init__.py
+++ b/gcpy/examples/working_with_files/__init__.py
@@ -1,7 +1,3 @@
 """
 GCPy example scripts for working with data files (e.g. netCDF).
 """
-from .add_blank_var_to_restart_file import *
-from .concatenate_files import *
-from .insert_field_into_restart_file import *
-from .regrid_restart_ll_to_cs import *

--- a/gcpy/examples/xarray_examples/__init__.py
+++ b/gcpy/examples/xarray_examples/__init__.py
@@ -1,6 +1,3 @@
 """
 GCPy initialization script: gcpy/src/examples
 """
-
-from . import *
-

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -18,6 +18,18 @@ from gcpy.cstools import get_cubed_sphere_res, is_gchp_lev_positive_down
 # Ignore any FutureWarnings
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
+# Ignore the RuntimeWarning that runpy emits because gcpy/__init__.py already
+# imports this module before "python -m gcpy.file_regrid" re-executes it
+warnings.filterwarnings(
+    "ignore",
+    category=RuntimeWarning,
+    message=r".*found in sys\.modules after import of package.*"
+)
+
+# Ignore benign UserWarnings that xesmf emits while constructing regridders
+# (F_CONTIGUOUS performance note, and ambiguous lat/lon dimension detection)
+warnings.filterwarnings("ignore", category=UserWarning, module=r"xesmf\..*")
+
 
 def file_regrid(
         filein,

--- a/gcpy/file_regrid.py
+++ b/gcpy/file_regrid.py
@@ -15,20 +15,21 @@ from gcpy.regrid import make_regridder_sg2sg, reformat_dims, \
 from gcpy.util import verify_variable_type
 from gcpy.cstools import get_cubed_sphere_res, is_gchp_lev_positive_down
 
-# Ignore any FutureWarnings
-warnings.simplefilter(action="ignore", category=FutureWarning)
-
-# Ignore the RuntimeWarning that runpy emits because gcpy/__init__.py already
-# imports this module before "python -m gcpy.file_regrid" re-executes it
+# Ignore benign warnings
+warnings.simplefilter(
+    action="ignore",
+    category=FutureWarning
+)
 warnings.filterwarnings(
     "ignore",
     category=RuntimeWarning,
     message=r".*found in sys\.modules after import of package.*"
 )
-
-# Ignore benign UserWarnings that xesmf emits while constructing regridders
-# (F_CONTIGUOUS performance note, and ambiguous lat/lon dimension detection)
-warnings.filterwarnings("ignore", category=UserWarning, module=r"xesmf\..*")
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    module=r"xesmf\..*"
+)
 
 
 def file_regrid(

--- a/gcpy/plot/core.py
+++ b/gcpy/plot/core.py
@@ -1,6 +1,7 @@
 """
 Common variables and functions used by modules in gcpy.plot.
 """
+import logging
 from os import path
 import warnings
 from matplotlib import colors
@@ -10,6 +11,13 @@ from gcpy.util import is_nearly_constant
 
 # Save warnings format to undo overwriting built into pypdf
 _warning_format = warnings.showwarning
+
+# Silence benign "findfont: Failed to find font weight ..." messages.
+# These come from Matplotlib's font_manager logger (not the warnings
+# module), and only indicate that the installed font family lacks an
+# exact-weight face for a style setting below (e.g. "medium");
+# Matplotlib already falls back to the closest available weight.
+logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
 
 # Current directory
 _plot_dir = path.dirname(__file__)

--- a/gcpy/plot/core.py
+++ b/gcpy/plot/core.py
@@ -13,10 +13,6 @@ from gcpy.util import is_nearly_constant
 _warning_format = warnings.showwarning
 
 # Silence benign "findfont: Failed to find font weight ..." messages.
-# These come from Matplotlib's font_manager logger (not the warnings
-# module), and only indicate that the installed font family lacks an
-# exact-weight face for a style setting below (e.g. "medium");
-# Matplotlib already falls back to the closest available weight.
 logging.getLogger("matplotlib.font_manager").setLevel(logging.ERROR)
 
 # Current directory

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ CLASSIFIERS = [
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
         "netcdf-fortran==4.6.1",
         "numpy==2.1.3",
         "pandas==2.2.3",
-        "pip==26.1.2",
+        "pip==26.2.1",
         "pylint==3.3.4",
         "pyproj==3.7.1",
         "python==3.13",


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard

### Describe the update

This PR does the following:

1. Adds `docs/environment_files/gcpy_environment_py314.yml` file, which can be used to build the GCPy Python environment with Python 3.14.  This also uses esmf/esmpy 8.9.2 instead of 8.8.1.   

2. Adds a new GitHub action to test building the environment with `gcpy_environment_py314.yml` 

3. Removed `from module import *` from `__init.py__` files in the `gcpy/examples/*` folders.  These were generating runtime warnings.

4. Adds code to `gcpy/plot/core.py` to squelch `findfont` warnings from the matplotlib library.

5. Updated ReadTheDocs documentation accordingly.  Added new package version numbers to the software dependencies table.

6. Updated pypdf to 6.16.1 and pip to 26.2.1 in all environment files, to resolve a security issue flagged by Dependabot.

7. Adds code to `gcpy/file_regrid.py` to squelch benign runtime warnings. 

### Expected changes
This allows building the GCPy environment with Python 3.14, which is the latest Python version.

### AI disclosure
- Update was generated and tested by Claude Code, verified by @yantosca