### PR TITLE
Pass "yaxis_units" to routine single_panel to allow zonal mean plots to have y-axis units of either level or pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added `gcpy/benchmark/modules/benchmark_gchp_stats.py`
 - Added routine to generate summary table to `gcpy/benchmark/modules/benchmark_species_changes.py`
-- Added `yaxis_units` kwarg to `gcpy/plot/single_panel.py` to display Y-axis as model levels instead of pressure
+- Added keyword argument `yaxis_units` to routines in:
+  - `gcpy/plot/compare_zonal_mean.py`
+  - `gcpy/plot/six_plot.py`
+  - `gcpy/plot/single_panel`
+  - `gcpy/benchmark/modules/benchmark_funcs.py`
+- Added `yaxis_units: pressure` to `gcpy/benchmark/config/*.yml` and `gcpy/benchmark/cloud/*.yml` files
 
 ### Changed
 - Bumped pytest to 9.0.3 and updated documentation accordingly
 - Updated paths to model vs observations data in 1-year benchmark yaml files
 - Passed kwarg `yaxis_units` down from `compare_zonal_mean` to `six_plot` to `single_panel`
+- Updated `run_benchmark*` routines to read `yaxis_units` from YAML files and to pass its value to relevant benchmark routines
 
 ### Fixed
 - Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated paths to model vs observations data in 1-year benchmark yaml files
 
 ### Fixed
+- Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids
 - Fixed a float32 overflow in `gcpy/benchmark/modules/oh_metrics.py` that produced `inf` global airmass, CH4 lifetime, and MCF lifetime values
 - Fixed tuple unpack error in `gcpy/benchmark/modules/benchmark_species_changes.py`
 - Fixed blank/white Ref and Dev panels for small-magnitude fields (e.g. emissions) in single-level six-panel plots in `gcpy/plot/core.py` and `gcpy/plot/six_plot.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `gcpy/benchmark/modules/benchmark_gchp_stats.py`
 - Added routine to generate summary table to `gcpy/benchmark/modules/benchmark_species_changes.py`
 - Added keyword argument `yaxis_units` to routines in:
-  - `gcpy/plot/compare_zonal_mean.py`
-  - `gcpy/plot/six_plot.py`
-  - `gcpy/plot/single_panel`
   - `gcpy/benchmark/modules/benchmark_funcs.py`
-- Added `yaxis_units: pressure` to `gcpy/benchmark/config/*.yml` and `gcpy/benchmark/cloud/*.yml` files
+  - `gcpy/examples/diagnostics/compare_diags.py`
+  - `gcpy/plot/compare_zonal_mean.py`
+  - `gcpy/plot/single_panel`
+  - `gcpy/plot/six_plot.py`
+- Added `yaxis_units: pressure` to the following YAML files:
+  - `gcpy/benchmark/config/*.yml`
+  - `gcpy/benchmark/cloud/*.yml`
+  - `gcpy/examples/diagnostics/compare_diags.yml`
 
 ### Changed
 - Bumped pytest to 9.0.3 and updated documentation accordingly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Bumped pytest to 9.0.3 and updated documentation accordingly
 - Updated paths to model vs observations data in 1-year benchmark yaml files
+- Passed kwarg `yaxis_units` down from `compare_zonal_mean` to `six_plot` to `single_panel`
 
 ### Fixed
 - Fixed `NameError` in `gcpy/regrid.py`'s `regrid_vertical` (stale `n_other` references left over from the `np_other` NumPy 2.0 compatibility rename) that broke any Ref vs. Dev zonal-mean comparison on mismatched vertical grids

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added `gcpy/benchmark/modules/benchmark_gchp_stats.py`
 - Added routine to generate summary table to `gcpy/benchmark/modules/benchmark_species_changes.py`
+- Added `yaxis_units` kwarg to `gcpy/plot/single_panel.py` to display Y-axis as model levels instead of pressure
 
 ### Changed
 - Bumped pytest to 9.0.3 and updated documentation accordingly

--- a/gcpy/benchmark/cloud/template.1hr_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1hr_benchmark.yml
@@ -126,6 +126,8 @@ options:
     plot_options:
       by_spc_cat: True
       by_hco_cat: True
+      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
+      yaxis_units: "pressure"
     #
     # Benchmark tables
     #

--- a/gcpy/benchmark/cloud/template.1mo_benchmark.yml
+++ b/gcpy/benchmark/cloud/template.1mo_benchmark.yml
@@ -127,6 +127,8 @@ options:
     plot_options:
       by_spc_cat: True
       by_hco_cat: True
+      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
+      yaxis_units: "pressure"
     #
     # Benchmark tables
     #

--- a/gcpy/benchmark/config/1mo_benchmark.yml
+++ b/gcpy/benchmark/config/1mo_benchmark.yml
@@ -123,6 +123,8 @@ options:
     plot_options:
       by_spc_cat: True
       by_hco_cat: True
+      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
+      yaxis_units: "pressure"
     #
     # Benchmark tables
     #

--- a/gcpy/benchmark/config/1yr_ch4_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_ch4_benchmark.yml
@@ -130,6 +130,8 @@ options:
     plot_options:
       by_spc_cat: True
       by_hco_cat: True
+      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
+      yaxis_units: "pressure"
   #
   # n_cores: Specify the number of cores to use.
   # -1: Use $OMP_NUM_THREADS         cores

--- a/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_fullchem_benchmark.yml
@@ -137,6 +137,8 @@ options:
     plot_options:
       by_spc_cat: True
       by_hco_cat: True
+      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
+      yaxis_units: "pressure"
     #
     # Benchmark tables
     #

--- a/gcpy/benchmark/config/1yr_tt_benchmark.yml
+++ b/gcpy/benchmark/config/1yr_tt_benchmark.yml
@@ -119,6 +119,9 @@ options:
     plot_conc: True
     plot_drydep: True
     plot_wetdep: True
+    plot_options:
+      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
+      yaxis_units: "pressure"
     #
     # Benchmark tables
     #

--- a/gcpy/benchmark/modules/benchmark_funcs.py
+++ b/gcpy/benchmark/modules/benchmark_funcs.py
@@ -880,6 +880,7 @@ def make_benchmark_conc_plots(
         plots=["sfc", "500hpa", "zonalmean"],
         use_cmap_RdBu=False,
         log_color_scale=False,
+        yaxis_units="pressure",
         sigdiff_files=None,
         normalize_by_area=False,
         cats_in_ugm3=["Aerosols", "Secondary_Organic_Aerosols"],
@@ -952,6 +953,10 @@ def make_benchmark_conc_plots(
         Set this flag to True to enable plotting data (not diffs)
         on a log color scale.
         Default value: False
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        Default value: "pressure"
     normalize_by_area : bool, optional
         Set this flag to true to enable normalization of data
         by surface area (i.e. kg s-1 --> kg s-1 m-2).
@@ -1244,6 +1249,7 @@ def make_benchmark_conc_plots(
             pdfname=pdfname,
             use_cmap_RdBu=use_cmap_RdBu,
             log_color_scale=log_color_scale,
+            yaxis_units=yaxis_units,
             normalize_by_area=normalize_by_area,
             extra_title_txt=extra_title_txt,
             weightsdir=weightsdir,
@@ -1498,6 +1504,7 @@ def make_benchmark_conc_plots(
                 pdfname=pdfname,
                 use_cmap_RdBu=use_cmap_RdBu,
                 log_color_scale=log_color_scale,
+                yaxis_units=yaxis_units,
                 normalize_by_area=normalize_by_area,
                 extra_title_txt=extra_title_txt,
                 sigdiff_list=diff_zm,
@@ -1544,6 +1551,7 @@ def make_benchmark_conc_plots(
                 use_cmap_RdBu=use_cmap_RdBu,
                 pres_range=[1, 100],
                 log_yaxis=True,
+                yaxis_units=yaxis_units,
                 extra_title_txt=extra_title_txt,
                 log_color_scale=log_color_scale,
                 normalize_by_area=normalize_by_area,
@@ -2295,6 +2303,7 @@ def make_benchmark_jvalue_plots(
         flip_ref=False,
         flip_dev=False,
         log_color_scale=False,
+        yaxis_units="pressure",
         sigdiff_files=None,
         weightsdir='.',
         n_job=-1,
@@ -2368,6 +2377,10 @@ def make_benchmark_jvalue_plots(
         Set this flag to True if you wish to enable plotting data
         (not diffs) on a log color scale.
         Default value: False
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        Default value: "pressure"
     sigdiff_files : list of str, optional
         Filenames that will contain the lists of J-values having
         significant differences in the 'sfc', '500hpa', and
@@ -2606,6 +2619,7 @@ def make_benchmark_jvalue_plots(
             flip_ref=flip_ref,
             flip_dev=flip_dev,
             log_color_scale=log_color_scale,
+            yaxis_units=yaxis_units,
             extra_title_txt=extra_title_txt,
             sigdiff_list=diff_zm,
             weightsdir=weightsdir,
@@ -2641,6 +2655,7 @@ def make_benchmark_jvalue_plots(
             pdfname=pdfname,
             pres_range=[1, 100],
             log_yaxis=True,
+            yaxis_units=yaxis_units,
             flip_ref=flip_ref,
             flip_dev=flip_dev,
             extra_title_txt=extra_title_txt,
@@ -2912,6 +2927,7 @@ def make_benchmark_collection_3d_var_plots(
         flip_ref=False,
         flip_dev=False,
         log_color_scale=False,
+        yaxis_units="pressure",
         weightsdir='.',
         n_job=-1,
         time_mean=False,
@@ -2977,6 +2993,10 @@ def make_benchmark_collection_3d_var_plots(
         Set this flag to True if you wish to enable plotting data
         (not diffs) on a log color scale.
         Default value: False
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        Default value: "pressure"
     weightsdir : str, optional
         Directory in which to place (and possibly reuse) xESMF regridder
         netCDF files.
@@ -3143,6 +3163,7 @@ def make_benchmark_collection_3d_var_plots(
             flip_ref=flip_ref,
             flip_dev=flip_dev,
             log_color_scale=log_color_scale,
+            yaxis_units=yaxis_units,
             extra_title_txt=extra_title_txt,
             weightsdir=weightsdir,
             n_job=n_job,
@@ -3170,6 +3191,7 @@ def make_benchmark_collection_3d_var_plots(
             pdfname=pdfname,
             pres_range=[1, 100],
             log_yaxis=True,
+            yaxis_units=yaxis_units,
             flip_ref=flip_ref,
             flip_dev=flip_dev,
             extra_title_txt=extra_title_txt,
@@ -4339,6 +4361,7 @@ def make_benchmark_wetdep_plots(
         benchmark_type="TransportTracersBenchmark",
         plots=["sfc", "500hpa", "zonalmean"],
         log_color_scale=False,
+        yaxis_units="pressure",
         normalize_by_area=False,
         areas=None,
         refmet=None,
@@ -4395,6 +4418,10 @@ def make_benchmark_wetdep_plots(
     log_color_scale : bool, optional
         Set this flag to True to enable plotting data (not diffs)
         on a log color scale.
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        Default value: "pressure"
     normalize_by_area : bool, optional
         Set this flag to true to enable normalization of data
         by surface area (i.e. kg s-1 --> kg s-1 m-2).
@@ -4556,6 +4583,7 @@ def make_benchmark_wetdep_plots(
             devmet=devmetds,
             pdfname=pdfname,
             log_color_scale=log_color_scale,
+            yaxis_units=yaxis_units,
             normalize_by_area=normalize_by_area,
             extra_title_txt=datestr,
             weightsdir=weightsdir,
@@ -4586,6 +4614,7 @@ def make_benchmark_wetdep_plots(
             pdfname=pdfname,
             pres_range=[1, 100],
             log_yaxis=True,
+            yaxis_units=yaxis_units,
             extra_title_txt=datestr,
             normalize_by_area=normalize_by_area,
             weightsdir=weightsdir,

--- a/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py
@@ -356,7 +356,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 weightsdir=config["paths"]["weights_dir"],
                 benchmark_type=bmk_type,
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -382,7 +383,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     plot_by_spc_cat=config["options"]["outputs"][
                         "plot_options"]["by_spc_cat"],
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -521,7 +523,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 time_mean=True,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -542,7 +545,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     subdst=bmk_mon_yr_strs_dev[mon],
                     weightsdir=config["paths"]["weights_dir"],
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -1013,7 +1017,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 weightsdir=config["paths"]["weights_dir"],
                 benchmark_type=bmk_type,
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -1039,7 +1044,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     plot_by_spc_cat=config["options"]["outputs"][
                         "plot_options"]["by_spc_cat"],
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==============================================================
@@ -1182,7 +1188,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 time_mean=True,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -1203,7 +1210,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     subdst=bmk_mon_yr_strs_dev[mon],
                     weightsdir=config["paths"]["weights_dir"],
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -1685,7 +1693,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 plot_by_spc_cat=config["options"]["outputs"][
                     "plot_options"]["by_spc_cat"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -1712,7 +1721,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     plot_by_spc_cat=config["options"]["outputs"][
                         "plot_options"]["by_spc_cat"],
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -1862,7 +1872,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 time_mean=True,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -1884,7 +1895,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     cmpres=cmpres,
                     weightsdir=config["paths"]["weights_dir"],
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -2396,7 +2408,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 second_ref=gcc_dev,
                 second_dev=gchp_dev,
                 cats_in_ugm3=None,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -2424,7 +2437,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     second_ref=gcc_dev[mon_ind],
                     second_dev=gchp_dev[mon_ind],
                     cats_in_ugm3=None,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
     # ==================================================================

--- a/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
+++ b/gcpy/benchmark/modules/run_1yr_tt_benchmark.py
@@ -332,7 +332,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 benchmark_type=bmk_type,
                 restrict_cats=restrict_cats,
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -355,7 +356,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     benchmark_type=bmk_type,
                     restrict_cats=restrict_cats,
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -402,7 +404,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     weightsdir=config["paths"]["weights_dir"],
                     benchmark_type=bmk_type,
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
                 # ----------------------------------------------------------
@@ -424,7 +427,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         weightsdir=config["paths"]["weights_dir"],
                         benchmark_type=bmk_type,
                         overwrite=True,
-                        n_job=config["options"]["n_cores"]
+                        n_job=config["options"]["n_cores"],
+                        yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                     )
 
 
@@ -695,7 +699,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 benchmark_type=bmk_type,
                 restrict_cats=restrict_cats,
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -718,7 +723,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     benchmark_type=bmk_type,
                     restrict_cats=restrict_cats,
                     overwrite=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -766,7 +772,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     overwrite=True,
                     benchmark_type=bmk_type,
                     normalize_by_area=True,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
                 # ----------------------------------------------------------
@@ -789,7 +796,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         overwrite=True,
                         benchmark_type=bmk_type,
                         normalize_by_area=True,
-                        n_job=config["options"]["n_cores"]
+                        n_job=config["options"]["n_cores"],
+                        yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                     )
 
         # ==================================================================
@@ -1011,7 +1019,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                 restrict_cats=restrict_cats,
                 overwrite=True,
                 cmpres=cmpres,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
             # --------------------------------------------------------------
@@ -1035,7 +1044,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     restrict_cats=restrict_cats,
                     overwrite=True,
                     cmpres=cmpres,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
         # ==================================================================
@@ -1086,7 +1096,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                     benchmark_type=bmk_type,
                     normalize_by_area=True,
                     cmpres=cmpres,
-                    n_job=config["options"]["n_cores"]
+                    n_job=config["options"]["n_cores"],
+                    yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                 )
 
                 # ----------------------------------------------------------
@@ -1110,7 +1121,8 @@ def run_benchmark(config, bmk_year_ref, bmk_year_dev):
                         benchmark_type=bmk_type,
                         normalize_by_area=True,
                         cmpres=cmpres,
-                        n_job=config["options"]["n_cores"]
+                        n_job=config["options"]["n_cores"],
+                        yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
                     )
 
         # ==================================================================

--- a/gcpy/benchmark/run_benchmark.py
+++ b/gcpy/benchmark/run_benchmark.py
@@ -389,7 +389,8 @@ def run_benchmark_default(config):
                 benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gcc_vs_gcc_sigdiff,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -466,7 +467,8 @@ def run_benchmark_default(config):
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
                 sigdiff_files=gcc_vs_gcc_sigdiff,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -519,7 +521,8 @@ def run_benchmark_default(config):
                 dst=gcc_vs_gcc_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -563,7 +566,8 @@ def run_benchmark_default(config):
                 dst=gcc_vs_gcc_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -963,7 +967,8 @@ def run_benchmark_default(config):
                 benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gcc_sigdiff,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1058,7 +1063,8 @@ def run_benchmark_default(config):
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gcc_sigdiff,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1121,7 +1127,8 @@ def run_benchmark_default(config):
                 dst=gchp_vs_gcc_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1165,7 +1172,8 @@ def run_benchmark_default(config):
                 dst=gchp_vs_gcc_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1573,7 +1581,8 @@ def run_benchmark_default(config):
                 benchmark_type=config["options"]["bmk_type"],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gchp_sigdiff,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1682,7 +1691,8 @@ def run_benchmark_default(config):
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
                 sigdiff_files=gchp_vs_gchp_sigdiff,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1755,7 +1765,8 @@ def run_benchmark_default(config):
                 dst=gchp_vs_gchp_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -1799,7 +1810,8 @@ def run_benchmark_default(config):
                 dst=gchp_vs_gchp_resultsdir,
                 weightsdir=config["paths"]["weights_dir"],
                 overwrite=True,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
         # ==================================================================
@@ -2252,7 +2264,8 @@ def run_benchmark_default(config):
                 second_ref=gcc_dev,
                 second_dev=gchp_dev,
                 cats_in_ugm3=None,
-                n_job=config["options"]["n_cores"]
+                n_job=config["options"]["n_cores"],
+                yaxis_units=config["options"]["outputs"].get("plot_options", {}).get("yaxis_units", "pressure"),
             )
 
 

--- a/gcpy/examples/diagnostics/compare_diags.py
+++ b/gcpy/examples/diagnostics/compare_diags.py
@@ -343,6 +343,8 @@ def compare_data(config, data):
             flip_ref=flip_ref,
             flip_dev=flip_dev,
             varlist=varlist_zonal,
+            yaxis_units=config[
+                "options"]["zonal_mean"].get("yaxis_units", "pressure"),
             pdfname=pdfname,
             weightsdir=config["paths"]["weights_dir"],
             n_job=config["options"]["n_cores"],

--- a/gcpy/examples/diagnostics/compare_diags.yml
+++ b/gcpy/examples/diagnostics/compare_diags.yml
@@ -26,6 +26,7 @@ options:
   zonal_mean:
     create_plot: True
     pdfname: zonal_mean_comparison.pdf
+    yaxis_units: "pressure"        # Values: pressure, level
   totals_and_diffs:
     create_table: True
     diff_type: absdiff             # Values: percent, pctdiff, %, abs, absdiff

--- a/gcpy/examples/plotting/plot_single_panel.py
+++ b/gcpy/examples/plotting/plot_single_panel.py
@@ -178,6 +178,19 @@ def single_panel_examples(infile, varname, level):
     )
     plt.show()
 
+    # You can instead display the Y-axis in model level units
+    # (useful for diagnostic purposes, e.g. stratosphere/mesosphere
+    # level changes) by setting yaxis_units="level"
+    single_panel(
+        darr,
+        pres_range=[0, 100],
+        yaxis_units="level",
+        log_color_scale=True,
+        plot_type="zonal_mean",
+        title=f"Zonal mean plot for {varname}, stratosphere-only, model level Y-axis"
+    )
+    plt.show()
+
 
 def main():
     """
@@ -214,7 +227,7 @@ def main():
     args = parser.parse_args()
 
     # Call the plot_single_panel routine
-    plot_single_panel_examples(
+    single_panel_examples(
         args.infile,
         args.varname,
         args.level

--- a/gcpy/plot/compare_zonal_mean.py
+++ b/gcpy/plot/compare_zonal_mean.py
@@ -62,6 +62,7 @@ def compare_zonal_mean(
         verbose=False,
         log_color_scale=False,
         log_yaxis=False,
+        yaxis_units="pressure",
         extra_title_txt=None,
         n_job=-1,
         sigdiff_list=None,
@@ -158,6 +159,18 @@ def compare_zonal_mean(
         Set this flag to True if you wish to create zonal mean
         plots with a log-pressure Y-axis.
         Default value: False
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        NOTE: If Ref and Dev are on different vertical grids (different
+        number of levels), the Ref and Dev panels use their own native
+        level numbering while the difference/ratio panels use the
+        common (smaller) target grid's level numbering, so level
+        numbers will not necessarily line up across all 6 panels.
+        This limitation does not apply to yaxis_units="pressure",
+        since both Ref and Dev are physically interpolated onto a
+        shared pressure grid.
+        Default value: "pressure"
     extra_title_txt : str, optional
         Specifies extra text (e.g. a date string such as "Jan2016")
         for the top-of-plot title.
@@ -1002,6 +1015,7 @@ def compare_zonal_mean(
                 pedge_inds[i],
                 log_yaxis,
                 plot_type="zonal_mean",
+                yaxis_units=yaxis_units,
                 xtick_positions=xtick_positions,
                 xticklabels=xticklabels,
                 ratio_log=ratio_logs[i],

--- a/gcpy/plot/single_panel.py
+++ b/gcpy/plot/single_panel.py
@@ -42,6 +42,7 @@ def single_panel(
         pedge=np.full((1, 1), -1),
         pedge_ind=np.full((1, 1), -1),
         log_yaxis=False,
+        yaxis_units="pressure",
         xtick_positions=None,
         xticklabels=None,
         proj=ccrs.PlateCarree(),
@@ -123,6 +124,11 @@ def single_panel(
         Set this flag to True to enable log scaling of pressure in
         zonal mean plots.
         Default value: False
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        log_yaxis is ignored when yaxis_units is "level".
+        Default value: "pressure"
     xtick_positions : list of float, optional
         Locations of lat/lon or lon ticks on plot.
         Default value: None (will place automatically for zonal mean plots)
@@ -174,6 +180,10 @@ def single_panel(
         Plot object created from input.
     """    
     verify_variable_type(plot_vals, (xr.DataArray, np.ndarray, DaskArray))
+    if yaxis_units not in ("pressure", "level"):
+        raise ValueError(
+            f"yaxis_units must be 'pressure' or 'level', got {yaxis_units!r}"
+        )
 
     # Create empty lists for keyword arguments
     if pres_range is None:
@@ -363,21 +373,28 @@ def single_panel(
     ax.set_title(title)
     if plot_type == "zonal_mean":
         # Zonal mean plot
+        if yaxis_units == "level":
+            yvals = pedge_ind
+        else:
+            yvals = pedge[pedge_ind]
         plot = ax.pcolormesh(
             grid["lat_b"],
-            pedge[pedge_ind],
+            yvals,
             plot_vals,
             cmap=comap,
             norm=norm,
             **extra_plot_args)
         ax.set_aspect("auto")
-        ax.set_ylabel("Pressure (hPa)")
-        if log_yaxis:
-            ax.set_yscale("log")
-            ax.yaxis.set_major_formatter(
-                ticker.FuncFormatter(lambda y, _: f"{y:g}")
-            )
-        ax.invert_yaxis()
+        if yaxis_units == "level":
+            ax.set_ylabel("Model Level")
+        else:
+            ax.set_ylabel("Pressure (hPa)")
+            if log_yaxis:
+                ax.set_yscale("log")
+                ax.yaxis.set_major_formatter(
+                    ticker.FuncFormatter(lambda y, _: f"{y:g}")
+                )
+            ax.invert_yaxis()
         ax.set_xticks(xtick_positions)
         ax.set_xticklabels(xticklabels)
 

--- a/gcpy/plot/six_plot.py
+++ b/gcpy/plot/six_plot.py
@@ -52,6 +52,7 @@ def six_plot(
         pedge=np.full((1, 1), -1),
         pedge_ind=np.full((1, 1), -1),
         log_yaxis=False,
+        yaxis_units="pressure",
         xtick_positions=None,
         xticklabels=None,
         plot_type="single_level",
@@ -127,6 +128,10 @@ def six_plot(
         Set this flag to True to enable log scaling of pressure
         in zonal mean plots.
         Default value: False
+    yaxis_units : str, optional
+        Units to use for the Y-axis of zonal mean plots. Either
+        "pressure" (hPa) or "level" (model vertical level index).
+        Default value: "pressure"
     xtick_positions : list of float, optional
         Locations of lat/lon or lon ticks on plot.
         Default value: None
@@ -203,6 +208,7 @@ def six_plot(
         pedge=pedge,
         pedge_ind=pedge_ind,
         log_yaxis=log_yaxis,
+        yaxis_units=yaxis_units,
         xtick_positions=xtick_positions,
         xticklabels=xticklabels,
         proj=proj,

--- a/gcpy/regrid.py
+++ b/gcpy/regrid.py
@@ -1175,9 +1175,9 @@ def regrid_vertical(src_data_3d, xmat_regrid, target_levs=None):
     except AttributeError:
         np_other = np.product(src_data_3d.shape[1:])   # NumPy < 2.0
     # ------------------------------------------------------------------
-    temp_data = np.zeros((nlev_out, n_other))
-    in_data = np.reshape(np.array(src_data_3d), (nlev_in, n_other))
-    for ix in range(n_other):
+    temp_data = np.zeros((nlev_out, np_other))
+    in_data = np.reshape(np.array(src_data_3d), (nlev_in, np_other))
+    for ix in range(np_other):
         in_data_vec = np.matrix(in_data[:, ix])
         temp_data[:, ix] = in_data_vec * xmat_renorm
     out_data = np.reshape(temp_data, out_shape)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Bob Yantosca
Institution: Harvard + GCST

### Describe the update
This PR adds an optional argument (`yaxis_units`) to routine `gcpy/plot/single_panel.py`.  

- If `yaxis_units="pressure"` (or is omitted), then zonal mean plots will use pressure (hPa) as the Y-axis (i.e. the status quo).  
- If `yaxis_units="level"`, then zonal mean plots will use model level as the Y-axis.

Related changes:

1. Added optional argument `yaxis_units` to routines in:

    - `gcpy/benchmark/modules/benchmark_funcs.py`
    - `gcpy/plot/compare_zonal_mean.py`
    - `gcpy/plot/six_plot.py`
 
2. Added `yaxis_units` to benchmark config YAML files (`gcpy/benchmark/config/*.yml` and `gcpy/benchmark/cloud/*.yml`):

```yaml
    plot_options:
      by_spc_cat: True
      by_hco_cat: True
      # yaxis_units: "pressure" or "level" for the zonal-mean plot Y-axis
      yaxis_units: "pressure"
```

3. Added `yaxis_units` to the `gcpy/examples/diagnostics/compare_diags.yml` file:
```yaml
options:
  ...
  zonal_mean:
    create_plot: True
    pdfname: zonal_mean_comparison.pdf
    yaxis_units: "pressure"        # Values: pressure, level
```

4. Routines in these modules read `yaxis_units` from YAML config files and pass its value to the relevant routines:

    - `gcpy/benchmark/run_benchmark.py`
    - `gcpy/benchmark/modules/run_1yr_fullchem_benchmark.py`
    - `gcpy/benchmark/modules/run_1yr_tt_benchmark.py`
    - `gcpy/examples/diagnostics/compare_diags.py`

### Expected changes
Here are some sample plots.

#### Figure 1. Zonal mean plot, Y-axis = pressure (i.e. the default option)

```python
    # Use the plot_type argument to specify zonal_mean plotting
    single_panel(
        darr,
        plot_type="zonal_mean",
        title=f"Zonal mean plot for {varname}, full atmosphere"
    )
    plt.show()
```
<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/77eb760c-55e2-4ba0-b994-3ffeb84ee9eb" />
nges

#### Figure 2. Zonal mean plot, stratosphere only, Y-axis = pressure (i.e. the default option)
```python
    # You can specify pressure ranges in hPa for zonal mean plot
    # (by default every vertical level is plotted)
    single_panel(
        darr,
        pres_range=[0, 100],
        log_yaxis=True,
        log_color_scale=True,
        plot_type="zonal_mean",
        title=f"Zonal mean plot for {varname}, stratosphere-only"
    )
    plt.show()
```
<img width="640" height="480" alt="Figure_2" src="https://github.com/user-attachments/assets/e98616de-0ce0-4d3a-8cda-5bd8c568b477" />

#### Figure 3. Zonal mean plot, stratosphere only, Y-axis = model level

```python
    # You can instead display the Y-axis in model level units
    # (useful for diagnostic purposes, e.g. stratosphere/mesosphere
    # level changes) by setting yaxis_units="level"
    single_panel(
        darr,
        pres_range=[0, 100],
        yaxis_units="level",  # <==== new setting here
        log_color_scale=True,
        plot_type="zonal_mean",
        title=f"Zonal mean plot for {varname}, stratosphere-only, model level Y-axis"
    )
    plt.show()
```
<img width="640" height="480" alt="Figure_3" src="https://github.com/user-attachments/assets/6533ec0f-3d63-4a66-befb-c59e3290dc6e" />

#### Figure 4: Six-panel zonal mean comparison plot, Y-axis = pressure.  (Only 1st row shown for brevity)
<img width="782" height="369" alt="Figure_4" src="https://github.com/user-attachments/assets/fd484b4c-ad72-4bfd-a6e2-231b0c47dad1" />

#### Figure 5: Six-panel zonal mean comparison plot, Y-axis = level.  (Only 1st row shown for brevity)
<img width="832" height="386" alt="Figure_5" src="https://github.com/user-attachments/assets/f139ea8d-004f-4e4b-b6d9-26562f47d012" />

### Related Github Issue
- Closes #442 

### AI disclosure
Generated by Claude Code, verified by @yantosca